### PR TITLE
Improve tests for equals and call assertions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,6 @@ install:
   - composer install
 php:
   - '7.2'
+  - '7.3'
+  - '7.4'
 script: vendor/bin/phpunit tests/

--- a/composer.json
+++ b/composer.json
@@ -29,9 +29,6 @@
         }
     },
     "autoload-dev": {
-        "classmap": [
-            "tests/TestCase.php"
-        ],
         "psr-4": {
             "Aranyasen\\HL7\\Tests\\": "tests/"
         }

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -36,10 +36,10 @@ class ConnectionTest extends TestCase
             $connection = new Connection('localhost', $this->port);
             $msg = new Message("MSH|^~\\&|1|\rPV1|1|O|^AAAA1^^^BB|", null, true, true);
             $ack = $connection->send($msg);
-            $this->assertInstanceOf(Message::class, $ack);
+            self::assertInstanceOf(Message::class, $ack);
             self::assertSame('MSH|^~\&|1||||||ACK|\nMSA|AA|\n|\n', $ack->toString());
 
-            $this->assertStringContainsString("MSH|^~\\&|1|\nPV1|1|O|^AAAA1^^^BB|", $this->getWhatServerGot());
+            self::assertStringContainsString("MSH|^~\\&|1|\nPV1|1|O|^AAAA1^^^BB|", $this->getWhatServerGot());
 
             $this->closeTcpSocket($connection->getSocket()); // Clean up listener
             pcntl_wait($status); // Wait till child is closed

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -204,7 +204,7 @@ class MessageTest extends TestCase
         $msg = new Message();
         $this->expectException(InvalidArgumentException::class);
         $msg->insertSegment(new Segment('ZZ1'), 3);
-        $this->assertEmpty($msg->getSegmentByIndex(3), 'Erroneous insert');
+        self::assertEmpty($msg->getSegmentByIndex(3), 'Erroneous insert');
     }
 
     /** @test */

--- a/tests/SegmentTest.php
+++ b/tests/SegmentTest.php
@@ -50,7 +50,7 @@ class SegmentTest extends TestCase
         $seg->setField(3, ['1', '2', '3']);
         self::assertIsArray($seg->getField(3), 'Composed field 1^2^3');
         self::assertCount(3, $seg->getField(3), 'Getting composed fields as array');
-        self::assertEquals(2, $seg->getField(3)[1], 'Getting single value from composed field');
+        self::assertSame('2', $seg->getField(3)[1], 'Getting single value from composed field');
     }
 
     /** @test */


### PR DESCRIPTION
# Changed log

- Add `php-7.3` and `php-7.4` version tests during Travis CI build.
- It's good enough to have the `PSR-4` namespace autoloading and it can remove `classmap` attribute for `tests/TestCase.php` class on `composer.json`.
- Using the `assertSame` to replace `assertEquals` assertions.
- The PHPUnit allows using the `self` and `$this` calls. To be consistency, it can use these test classes with `self` assertion call.