### PR TITLE
Add docblock to segment getter/setter methods

### DIFF
--- a/docs/Connection.md
+++ b/docs/Connection.md
@@ -4,9 +4,7 @@ Usage:
 ```php
 $connection = new Connection('127.0.0.1', 5002);
 $req = new Message();
-// .
-
-.. set some request attributes
+// ... set some request attributes
 $response = $connection->send($req);
 $response->toString(); // Read ACK message from remote
 ```
@@ -36,6 +34,7 @@ End of message signal for HL7 server. Defaults to \034\015.
 |------|-------------|
 |[__construct](#connection__construct)|Creates a connection to a HL7 server, or throws exception when a connection could not be established.|
 |[__destruct](#connection__destruct)||
+|[getSocket](#connectiongetsocket)||
 |[send](#connectionsend)|Sends a Message object over this connection.|
 
 
@@ -46,7 +45,7 @@ End of message signal for HL7 server. Defaults to \034\015.
 **Description**
 
 ```php
-public __construct (string $host, string $port)
+public __construct (string $host, int $port, int $timeout)
 ```
 
 Creates a connection to a HL7 server, or throws exception when a connection could not be established. 
@@ -57,12 +56,21 @@ Creates a connection to a HL7 server, or throws exception when a connection coul
 
 * `(string) $host`
 : Host to connect to  
-* `(string) $port`
+* `(int) $port`
 : Port to connect to  
+* `(int) $timeout`
+: Connection timeout  
 
 **Return Values**
 
 `void`
+
+
+**Throws Exceptions**
+
+
+`\HL7ConnectionException`
+
 
 <hr />
 
@@ -72,7 +80,7 @@ Creates a connection to a HL7 server, or throws exception when a connection coul
 **Description**
 
 ```php
-public __destruct (void)
+ __destruct (void)
 ```
 
  
@@ -87,6 +95,31 @@ public __destruct (void)
 
 `void`
 
+
+<hr />
+
+
+### Connection::getSocket  
+
+**Description**
+
+```php
+ getSocket (void)
+```
+
+ 
+
+ 
+
+**Parameters**
+
+`This function has no parameters.`
+
+**Return Values**
+
+`void`
+
+
 <hr />
 
 
@@ -95,7 +128,7 @@ public __destruct (void)
 **Description**
 
 ```php
-public send (\Message $req, string $responseCharEncoding)
+public send (string $responseCharEncoding, bool $noWait)
 ```
 
 Sends a Message object over this connection. 
@@ -104,14 +137,23 @@ Sends a Message object over this connection.
 
 **Parameters**
 
-* `(\Message) $req`
 * `(string) $responseCharEncoding`
 : The expected character encoding of the response.  
+* `(bool) $noWait`
+: Do no wait for ACK. Helpful for building load testing tools...  
 
 **Return Values**
 
-`\Message`
+`void`
 
+
+**Throws Exceptions**
+
+
+`\HL7ConnectionException`
+
+
+`\HL7Exception`
 
 
 <hr />

--- a/docs/Message.md
+++ b/docs/Message.md
@@ -18,15 +18,27 @@ The segment separator defaults to \015. To change this, set the global variable 
 |------|-------------|
 |[__construct](#message__construct)|Constructor for Message. Consider using the HL7 factory to obtain a message instead.|
 |[addSegment](#messageaddsegment)|Append a segment to the end of the message|
+|[getFirstSegmentInstance](#messagegetfirstsegmentinstance)|Return the first segment with given name in the message|
 |[getSegmentAsString](#messagegetsegmentasstring)|Get the segment identified by index as string, using the messages separators.|
 |[getSegmentByIndex](#messagegetsegmentbyindex)|Return the segment specified by $index.|
 |[getSegmentFieldAsString](#messagegetsegmentfieldasstring)|Get the field identified by $fieldIndex from segment $segmentIndex.|
+|[getSegmentIndex](#messagegetsegmentindex)||
 |[getSegments](#messagegetsegments)|Return an array containing all segments in the right order.|
 |[getSegmentsByName](#messagegetsegmentsbyname)|Return an array of all segments with the given name|
+|[hasSegment](#messagehassegment)|Check if given segment is present in the message object|
 |[insertSegment](#messageinsertsegment)|Insert a segment.|
+|[isAdt](#messageisadt)||
+|[isEmpty](#messageisempty)||
+|[isOrm](#messageisorm)||
+|[isOru](#messageisoru)||
+|[isSiu](#messageissiu)||
+|[removeSegment](#messageremovesegment)||
 |[removeSegmentByIndex](#messageremovesegmentbyindex)|Remove the segment indexed by $index.|
+|[removeSegmentsByName](#messageremovesegmentsbyname)|Remove given segment|
+|[resetSegmentIndices](#messageresetsegmentindices)|Reset index attribute of each given segment, so when those are added the indices start from 1|
 |[segmentToString](#messagesegmenttostring)|Convert Segment object to string|
 |[setSegment](#messagesetsegment)|Set the segment on index.|
+|[toFile](#messagetofile)|Write HL7 to a file|
 |[toString](#messagetostring)|Return a string representation of this message.|
 
 
@@ -37,7 +49,7 @@ The segment separator defaults to \015. To change this, set the global variable 
 **Description**
 
 ```php
-public __construct (string $msgStr, array $hl7Globals)
+public __construct (string|null $msgStr, array|null $hl7Globals, bool $keepEmptySubFields, bool $resetIndices, bool $autoIncrementIndices, bool|null $doNotSplitRepetition)
 ```
 
 Constructor for Message. Consider using the HL7 factory to obtain a message instead. 
@@ -56,12 +68,29 @@ If the message couldn't be created, for example due to a erroneous HL7 message s
 
 **Parameters**
 
-* `(string) $msgStr`
-* `(array) $hl7Globals`
+* `(string|null) $msgStr`
+* `(array|null) $hl7Globals`
+: Set control characters or HL7 properties. e.g., ['HL7_VERSION' => '2.5']  
+* `(bool) $keepEmptySubFields`
+: Set this to true to retain empty sub-fields  
+* `(bool) $resetIndices`
+: Reset Indices of each segment to 1.  
+* `(bool) $autoIncrementIndices`
+: True: auto-increment for each instance of same segment.  
+* `(bool|null) $doNotSplitRepetition`
+: If true, repeated segments will be in single array instead of sub-arrays.  
+Note: Since this is non-standard, it may be removed in future!  
 
 **Return Values**
 
 `void`
+
+
+**Throws Exceptions**
+
+
+`\HL7Exception`
+
 
 <hr />
 
@@ -71,7 +100,7 @@ If the message couldn't be created, for example due to a erroneous HL7 message s
 **Description**
 
 ```php
-public addSegment (\Segment $segment)
+public addSegment (void)
 ```
 
 Append a segment to the end of the message 
@@ -80,11 +109,36 @@ Append a segment to the end of the message
 
 **Parameters**
 
-* `(\Segment) $segment`
+`This function has no parameters.`
 
 **Return Values**
 
-`bool`
+`void`
+
+
+<hr />
+
+
+### Message::getFirstSegmentInstance  
+
+**Description**
+
+```php
+public getFirstSegmentInstance (void)
+```
+
+Return the first segment with given name in the message 
+
+ 
+
+**Parameters**
+
+`This function has no parameters.`
+
+**Return Values**
+
+`mixed|null`
+
 
 
 
@@ -114,6 +168,7 @@ Get the segment identified by index as string, using the messages separators.
 
 > String representation of segment
 
+
 <hr />
 
 
@@ -136,8 +191,7 @@ Note: Segment count within the message starts at 0.
 
 **Return Values**
 
-`\Segment`
-
+`void`
 
 
 <hr />
@@ -164,9 +218,34 @@ Returns empty string if field is not set.
 
 **Return Values**
 
-`mixed`
+`null|string`
 
 > String representation of field
+
+
+<hr />
+
+
+### Message::getSegmentIndex  
+
+**Description**
+
+```php
+ getSegmentIndex (void)
+```
+
+ 
+
+ 
+
+**Parameters**
+
+`This function has no parameters.`
+
+**Return Values**
+
+`void`
+
 
 <hr />
 
@@ -192,6 +271,7 @@ Return an array containing all segments in the right order.
 `array`
 
 > List of all segments
+
 
 <hr />
 
@@ -219,6 +299,31 @@ Return an array of all segments with the given name
 
 > List of segments identified by name
 
+
+<hr />
+
+
+### Message::hasSegment  
+
+**Description**
+
+```php
+public hasSegment (void)
+```
+
+Check if given segment is present in the message object 
+
+ 
+
+**Parameters**
+
+`This function has no parameters.`
+
+**Return Values**
+
+`void`
+
+
 <hr />
 
 
@@ -227,7 +332,7 @@ Return an array of all segments with the given name
 **Description**
 
 ```php
-public insertSegment (\Segment $segment, null|int $index)
+public insertSegment (null|int $index)
 ```
 
 Insert a segment. 
@@ -236,13 +341,163 @@ Insert a segment.
 
 **Parameters**
 
-* `(\Segment) $segment`
 * `(null|int) $index`
 : Index where segment is inserted  
 
 **Return Values**
 
 `void`
+
+
+**Throws Exceptions**
+
+
+`\InvalidArgumentException`
+
+
+<hr />
+
+
+### Message::isAdt  
+
+**Description**
+
+```php
+ isAdt (void)
+```
+
+ 
+
+ 
+
+**Parameters**
+
+`This function has no parameters.`
+
+**Return Values**
+
+`void`
+
+
+<hr />
+
+
+### Message::isEmpty  
+
+**Description**
+
+```php
+ isEmpty (void)
+```
+
+ 
+
+ 
+
+**Parameters**
+
+`This function has no parameters.`
+
+**Return Values**
+
+`void`
+
+
+<hr />
+
+
+### Message::isOrm  
+
+**Description**
+
+```php
+ isOrm (void)
+```
+
+ 
+
+ 
+
+**Parameters**
+
+`This function has no parameters.`
+
+**Return Values**
+
+`void`
+
+
+<hr />
+
+
+### Message::isOru  
+
+**Description**
+
+```php
+ isOru (void)
+```
+
+ 
+
+ 
+
+**Parameters**
+
+`This function has no parameters.`
+
+**Return Values**
+
+`void`
+
+
+<hr />
+
+
+### Message::isSiu  
+
+**Description**
+
+```php
+ isSiu (void)
+```
+
+ 
+
+ 
+
+**Parameters**
+
+`This function has no parameters.`
+
+**Return Values**
+
+`void`
+
+
+<hr />
+
+
+### Message::removeSegment  
+
+**Description**
+
+```php
+ removeSegment (void)
+```
+
+ 
+
+ 
+
+**Parameters**
+
+`This function has no parameters.`
+
+**Return Values**
+
+`void`
+
 
 <hr />
 
@@ -267,8 +522,57 @@ after this one will be moved one index up.
 
 **Return Values**
 
-`boolean`
+`void`
 
+
+<hr />
+
+
+### Message::removeSegmentsByName  
+
+**Description**
+
+```php
+public removeSegmentsByName (void)
+```
+
+Remove given segment 
+
+ 
+
+**Parameters**
+
+`This function has no parameters.`
+
+**Return Values**
+
+`int`
+
+> Count of segments removed
+
+
+<hr />
+
+
+### Message::resetSegmentIndices  
+
+**Description**
+
+```php
+public resetSegmentIndices (void)
+```
+
+Reset index attribute of each given segment, so when those are added the indices start from 1 
+
+ 
+
+**Parameters**
+
+`This function has no parameters.`
+
+**Return Values**
+
+`void`
 
 
 <hr />
@@ -279,7 +583,7 @@ after this one will be moved one index up.
 **Description**
 
 ```php
-public segmentToString ( $seg)
+public segmentToString (void)
 ```
 
 Convert Segment object to string 
@@ -288,12 +592,11 @@ Convert Segment object to string
 
 **Parameters**
 
-* `() $seg`
+`This function has no parameters.`
 
 **Return Values**
 
-`string`
-
+`void`
 
 
 <hr />
@@ -304,7 +607,7 @@ Convert Segment object to string
 **Description**
 
 ```php
-public setSegment (\Segment $segment, int $index)
+public setSegment (int $index)
 ```
 
 Set the segment on index. 
@@ -314,14 +617,48 @@ control characters and hl7 version, based on MSH(1), MSH(2) and MSH(12).
 
 **Parameters**
 
-* `(\Segment) $segment`
 * `(int) $index`
 : Index where segment is set  
 
 **Return Values**
 
-`boolean`
+`void`
 
+
+**Throws Exceptions**
+
+
+`\InvalidArgumentException`
+
+
+<hr />
+
+
+### Message::toFile  
+
+**Description**
+
+```php
+public toFile (void)
+```
+
+Write HL7 to a file 
+
+ 
+
+**Parameters**
+
+`This function has no parameters.`
+
+**Return Values**
+
+`void`
+
+
+**Throws Exceptions**
+
+
+`\HL7Exception`
 
 
 <hr />
@@ -332,7 +669,7 @@ control characters and hl7 version, based on MSH(1), MSH(2) and MSH(12).
 **Description**
 
 ```php
-public toString (boolean $pretty)
+public toString (bool $pretty)
 ```
 
 Return a string representation of this message. 
@@ -342,7 +679,7 @@ argument as some true value. This will not use the default segment separator, bu
 
 **Parameters**
 
-* `(boolean) $pretty`
+* `(bool) $pretty`
 : Whether to use \n as separator or default (\r).  
 
 **Return Values**
@@ -350,6 +687,13 @@ argument as some true value. This will not use the default segment separator, bu
 `mixed`
 
 > String representation of HL7 message
+
+
+**Throws Exceptions**
+
+
+`\HL7Exception`
+
 
 <hr />
 

--- a/docs/Messages/ACK.md
+++ b/docs/Messages/ACK.md
@@ -13,7 +13,7 @@ Aranyasen\HL7\Message
 | Name | Description |
 |------|-------------|
 |[setAckCode](#acksetackcode)|Set the acknowledgement code for the acknowledgement.|
-|[setErrorMessage](#ackseterrormessage)|Set the error message for the acknowledgement.|
+|[setErrorMessage](#ackseterrormessage)|Set the error message for acknowledgement.|
 
 ## Inherited methods
 
@@ -21,15 +21,27 @@ Aranyasen\HL7\Message
 |------|-------------|
 |__construct|Constructor for Message. Consider using the HL7 factory to obtain a message instead.|
 |addSegment|Append a segment to the end of the message|
+|getFirstSegmentInstance|Return the first segment with given name in the message|
 |getSegmentAsString|Get the segment identified by index as string, using the messages separators.|
 |getSegmentByIndex|Return the segment specified by $index.|
 |getSegmentFieldAsString|Get the field identified by $fieldIndex from segment $segmentIndex.|
+| [getSegmentIndex](https://secure.php.net/manual/en/aranyasen\hl7\message.getsegmentindex.php) | - |
 |getSegments|Return an array containing all segments in the right order.|
 |getSegmentsByName|Return an array of all segments with the given name|
+|hasSegment|Check if given segment is present in the message object|
 |insertSegment|Insert a segment.|
+| [isAdt](https://secure.php.net/manual/en/aranyasen\hl7\message.isadt.php) | - |
+| [isEmpty](https://secure.php.net/manual/en/aranyasen\hl7\message.isempty.php) | - |
+| [isOrm](https://secure.php.net/manual/en/aranyasen\hl7\message.isorm.php) | - |
+| [isOru](https://secure.php.net/manual/en/aranyasen\hl7\message.isoru.php) | - |
+| [isSiu](https://secure.php.net/manual/en/aranyasen\hl7\message.issiu.php) | - |
+| [removeSegment](https://secure.php.net/manual/en/aranyasen\hl7\message.removesegment.php) | - |
 |removeSegmentByIndex|Remove the segment indexed by $index.|
+|removeSegmentsByName|Remove given segment|
+|resetSegmentIndices|Reset index attribute of each given segment, so when those are added the indices start from 1|
 |segmentToString|Convert Segment object to string|
 |setSegment|Set the segment on index.|
+|toFile|Write HL7 to a file|
 |toString|Return a string representation of this message.|
 
 
@@ -39,7 +51,7 @@ Aranyasen\HL7\Message
 **Description**
 
 ```php
-public setAckCode (string $code, string $msg)
+public setAckCode (string $code, string|null $msg)
 ```
 
 Set the acknowledgement code for the acknowledgement. 
@@ -52,13 +64,12 @@ This denotes: accept, general error and reject respectively. The ACK module will
 
 * `(string) $code`
 : Code to use in acknowledgement  
-* `(string) $msg`
+* `(string|null) $msg`
 : Acknowledgement message  
 
 **Return Values**
 
-`boolean`
-
+`void`
 
 
 <hr />
@@ -72,7 +83,7 @@ This denotes: accept, general error and reject respectively. The ACK module will
 public setErrorMessage (string $msg)
 ```
 
-Set the error message for the acknowledgement. 
+Set the error message for acknowledgement. 
 
 This will also set the error code to either AE or CE, depending on the mode of the incoming message. 
 
@@ -84,6 +95,7 @@ This will also set the error code to either AE or CE, depending on the mode of t
 **Return Values**
 
 `void`
+
 
 <hr />
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,3 +14,6 @@
 * [Segments\OBX](Segments/OBX.md) 
 * [Segments\ORC](Segments/ORC.md) 
 * [Segments\PV1](Segments/PV1.md) 
+* [Segments\EVN](Segments/EVN.md) 
+* [Segments\EQU](Segments/EQU.md) 
+* [Segments\SAC](Segments/SAC.md) 

--- a/docs/Segment.md
+++ b/docs/Segment.md
@@ -11,6 +11,7 @@
 | Name | Description |
 |------|-------------|
 |[__construct](#segment__construct)|Create a segment.|
+|[clearField](#segmentclearfield)|Remove any existing value from the field|
 |[getField](#segmentgetfield)|Get the field at index.|
 |[getFields](#segmentgetfields)|Get fields from a segment|
 |[getName](#segmentgetname)|Get the name of the segment. This is basically the value at index 0|
@@ -30,11 +31,11 @@ public __construct (string $name, array|null $fields)
 
 Create a segment. 
 
-A segment may be created with just a name or a name and an array of field  
-values. The segment name should be a standard HL7 segment (e.g. MSH / PID etc.) that is three characters long, and  
-upper case. If an array is given, all fields will be filled from that array. Note that for composed fields and  
-sub-components, the array may hold sub-arrays and sub-sub-arrays. Repeated fields can not be supported the same  
-way, since we can't distinguish between composed fields and repeated fields.  
+A segment may be created with just a name or a name and an array of field values. The segment name should be a  
+standard HL7 segment (e.g. MSH / PID etc.) that is three characters long, and upper case. If an array is given,  
+all fields will be filled from that array. Note that for composed fields and sub-components, the array may hold  
+sub-arrays and sub-sub-arrays. Repeated fields can not be supported the same way, since we can't distinguish  
+between composed fields and repeated fields.  
   
 Example:  
 ```php  
@@ -55,6 +56,38 @@ echo $seg->getField(1);
 
 `void`
 
+
+**Throws Exceptions**
+
+
+`\InvalidArgumentException`
+
+
+<hr />
+
+
+### Segment::clearField  
+
+**Description**
+
+```php
+public clearField (int $index)
+```
+
+Remove any existing value from the field 
+
+ 
+
+**Parameters**
+
+* `(int) $index`
+: Field index  
+
+**Return Values**
+
+`void`
+
+
 <hr />
 
 
@@ -63,7 +96,7 @@ echo $seg->getField(1);
 **Description**
 
 ```php
-public getField (int $index)
+public getField (void)
 ```
 
 Get the field at index. 
@@ -76,14 +109,12 @@ $field = $seg->getField(9); // Returns a string/null/array depending on what the
 
 **Parameters**
 
-* `(int) $index`
-: Index of field  
+`This function has no parameters.`
 
 **Return Values**
 
-`null|string|array`
+`void`
 
-> The value of the field
 
 <hr />
 
@@ -114,6 +145,7 @@ fields from this index till the end of the segment will be returned.
 
 > List of fields
 
+
 <hr />
 
 
@@ -135,9 +167,10 @@ Get the name of the segment. This is basically the value at index 0
 
 **Return Values**
 
-`mixed`
+`string`
 
 > Name of segment
+
 
 <hr />
 
@@ -147,7 +180,7 @@ Get the name of the segment. This is basically the value at index 0
 **Description**
 
 ```php
-public setField (int $index, string|array $value)
+public setField (int $index)
 ```
 
 Set the field specified by index to value. 
@@ -170,13 +203,10 @@ If values are not provided at all, the method will just return.
 
 * `(int) $index`
 : Index to set  
-* `(string|array) $value`
-: Value for field  
 
 **Return Values**
 
-`boolean`
-
+`void`
 
 
 <hr />
@@ -203,6 +233,7 @@ Get the number of fields for this segment, not including the name
 `int`
 
 > number of fields
+
 
 <hr />
 

--- a/docs/Segments/DG1.md
+++ b/docs/Segments/DG1.md
@@ -13,50 +13,53 @@ Aranyasen\HL7\Segment
 
 | Name | Description |
 |------|-------------|
-|[getAttestationDateTime](#dg1getattestationdatetime)||
-|[getConfidentialIndicator](#dg1getconfidentialindicator)||
-|[getDRGApprovalIndicator](#dg1getdrgapprovalindicator)||
-|[getDRGGrouperReviewCode](#dg1getdrggrouperreviewcode)||
-|[getDiagnosingClinician](#dg1getdiagnosingclinician)||
-|[getDiagnosisClassification](#dg1getdiagnosisclassification)||
+|[__destruct](#dg1__destruct)||
+|[getAttestationDateTime](#dg1getattestationdatetime)|Get Attestation DateTime (OBR.19)|
+|[getConfidentialIndicator](#dg1getconfidentialindicator)|Get Confidential Indicator (OBR.18)|
+|[getDRGApprovalIndicator](#dg1getdrgapprovalindicator)|Get DRGApproval Indicator (OBR.9)|
+|[getDRGGrouperReviewCode](#dg1getdrggrouperreviewcode)|Get DRGGrouper ReviewCode (OBR.10)|
+|[getDiagnosingClinician](#dg1getdiagnosingclinician)|Get Diagnosing Clinician (OBR.16)|
+|[getDiagnosisClassification](#dg1getdiagnosisclassification)|Get Diagnosis Classification (OBR.17)|
 |[getDiagnosisCodeDG1](#dg1getdiagnosiscodedg1)||
-|[getDiagnosisCodingMethod](#dg1getdiagnosiscodingmethod)||
-|[getDiagnosisDateTime](#dg1getdiagnosisdatetime)||
-|[getDiagnosisDescription](#dg1getdiagnosisdescription)||
-|[getDiagnosisPriority](#dg1getdiagnosispriority)||
-|[getDiagnosisType](#dg1getdiagnosistype)||
-|[getDiagnosticRelatedGroup](#dg1getdiagnosticrelatedgroup)||
-|[getGrouperVersionAndType](#dg1getgrouperversionandtype)||
-|[getID](#dg1getid)||
-|[getMajorDiagnosticCategory](#dg1getmajordiagnosticcategory)||
-|[getOutlierCost](#dg1getoutliercost)||
-|[getOutlierDays](#dg1getoutlierdays)||
-|[getOutlierType](#dg1getoutliertype)||
-|[setAttestationDateTime](#dg1setattestationdatetime)||
-|[setConfidentialIndicator](#dg1setconfidentialindicator)||
-|[setDRGApprovalIndicator](#dg1setdrgapprovalindicator)||
-|[setDRGGrouperReviewCode](#dg1setdrggrouperreviewcode)||
-|[setDiagnosingClinician](#dg1setdiagnosingclinician)||
-|[setDiagnosisClassification](#dg1setdiagnosisclassification)||
+|[getDiagnosisCodingMethod](#dg1getdiagnosiscodingmethod)|Get Diagnosis CodingMethod (OBR.2)|
+|[getDiagnosisDateTime](#dg1getdiagnosisdatetime)|Get Diagnosis DateTime (OBR.5)|
+|[getDiagnosisDescription](#dg1getdiagnosisdescription)|Get Diagnosis Description (OBR.4)|
+|[getDiagnosisPriority](#dg1getdiagnosispriority)|Get Diagnosis Priority (OBR.15)|
+|[getDiagnosisType](#dg1getdiagnosistype)|Get Diagnosis Type (OBR.6)|
+|[getDiagnosticRelatedGroup](#dg1getdiagnosticrelatedgroup)|Get Diagnostic RelatedGroup (OBR.8)|
+|[getGrouperVersionAndType](#dg1getgrouperversionandtype)|Get Grouper VersionAndType (OBR.14)|
+|[getID](#dg1getid)|Get ID (OBR.1)|
+|[getMajorDiagnosticCategory](#dg1getmajordiagnosticcategory)|Get Major DiagnosticCategory (OBR.7)|
+|[getOutlierCost](#dg1getoutliercost)|Get Outlier Cost (OBR.13)|
+|[getOutlierDays](#dg1getoutlierdays)|Get Outlier Days (OBR.12)|
+|[getOutlierType](#dg1getoutliertype)|Get Outlier Type (OBR.11)|
+|[resetIndex](#dg1resetindex)|Reset index of this segment|
+|[setAttestationDateTime](#dg1setattestationdatetime)|Set Attestation DateTime (OBR.19)|
+|[setConfidentialIndicator](#dg1setconfidentialindicator)|Set Confidential Indicator (OBR.18)|
+|[setDRGApprovalIndicator](#dg1setdrgapprovalindicator)|Set DRGApproval Indicator (OBR.9)|
+|[setDRGGrouperReviewCode](#dg1setdrggrouperreviewcode)|Set DRGGrouper ReviewCode (OBR.10)|
+|[setDiagnosingClinician](#dg1setdiagnosingclinician)|Set Diagnosing Clinician (OBR.16)|
+|[setDiagnosisClassification](#dg1setdiagnosisclassification)|Set Diagnosis Classification (OBR.17)|
 |[setDiagnosisCodeDG1](#dg1setdiagnosiscodedg1)||
-|[setDiagnosisCodingMethod](#dg1setdiagnosiscodingmethod)||
-|[setDiagnosisDateTime](#dg1setdiagnosisdatetime)||
-|[setDiagnosisDescription](#dg1setdiagnosisdescription)||
-|[setDiagnosisPriority](#dg1setdiagnosispriority)||
-|[setDiagnosisType](#dg1setdiagnosistype)||
-|[setDiagnosticRelatedGroup](#dg1setdiagnosticrelatedgroup)||
-|[setGrouperVersionAndType](#dg1setgrouperversionandtype)||
+|[setDiagnosisCodingMethod](#dg1setdiagnosiscodingmethod)|Set Diagnosis CodingMethod (OBR.2)|
+|[setDiagnosisDateTime](#dg1setdiagnosisdatetime)|Set Diagnosis DateTime (OBR.5)|
+|[setDiagnosisDescription](#dg1setdiagnosisdescription)|Set Diagnosis Description (OBR.4)|
+|[setDiagnosisPriority](#dg1setdiagnosispriority)|Set Diagnosis Priority (OBR.15)|
+|[setDiagnosisType](#dg1setdiagnosistype)|Set Diagnosis Type (OBR.6)|
+|[setDiagnosticRelatedGroup](#dg1setdiagnosticrelatedgroup)|Set Diagnostic RelatedGroup (OBR.8)|
+|[setGrouperVersionAndType](#dg1setgrouperversionandtype)|Set Grouper VersionAndType (OBR.14)|
 |[setID](#dg1setid)||
-|[setMajorDiagnosticCategory](#dg1setmajordiagnosticcategory)||
-|[setOutlierCost](#dg1setoutliercost)||
-|[setOutlierDays](#dg1setoutlierdays)||
-|[setOutlierType](#dg1setoutliertype)||
+|[setMajorDiagnosticCategory](#dg1setmajordiagnosticcategory)|Set Major DiagnosticCategory (OBR.7)|
+|[setOutlierCost](#dg1setoutliercost)|Set Outlier Cost (OBR.13)|
+|[setOutlierDays](#dg1setoutlierdays)|Set Outlier Days (OBR.12)|
+|[setOutlierType](#dg1setoutliertype)|Set Outlier Type (OBR.11)|
 
 ## Inherited methods
 
 | Name | Description |
 |------|-------------|
 |__construct|Create a segment.|
+|clearField|Remove any existing value from the field|
 |getField|Get the field at index.|
 |getFields|Get fields from a segment|
 |getName|Get the name of the segment. This is basically the value at index 0|
@@ -65,12 +68,12 @@ Aranyasen\HL7\Segment
 
 
 
-### DG1::getAttestationDateTime  
+### DG1::__destruct  
 
 **Description**
 
 ```php
-public getAttestationDateTime (void)
+ __destruct (void)
 ```
 
  
@@ -84,6 +87,34 @@ public getAttestationDateTime (void)
 **Return Values**
 
 `void`
+
+
+<hr />
+
+
+### DG1::getAttestationDateTime  
+
+**Description**
+
+```php
+public getAttestationDateTime (int $position)
+```
+
+Get Attestation DateTime (OBR.19) 
+
+ 
+
+**Parameters**
+
+* `(int) $position`
+: Defaults to 19  
+
+**Return Values**
+
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -93,20 +124,24 @@ public getAttestationDateTime (void)
 **Description**
 
 ```php
-public getConfidentialIndicator (void)
+public getConfidentialIndicator (int $position)
 ```
 
- 
+Get Confidential Indicator (OBR.18) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 18  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -116,20 +151,24 @@ public getConfidentialIndicator (void)
 **Description**
 
 ```php
-public getDRGApprovalIndicator (void)
+public getDRGApprovalIndicator (int $position)
 ```
 
- 
+Get DRGApproval Indicator (OBR.9) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 9  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -139,20 +178,24 @@ public getDRGApprovalIndicator (void)
 **Description**
 
 ```php
-public getDRGGrouperReviewCode (void)
+public getDRGGrouperReviewCode (int $position)
 ```
 
- 
+Get DRGGrouper ReviewCode (OBR.10) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 10  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -162,20 +205,24 @@ public getDRGGrouperReviewCode (void)
 **Description**
 
 ```php
-public getDiagnosingClinician (void)
+public getDiagnosingClinician (int $position)
 ```
 
- 
+Get Diagnosing Clinician (OBR.16) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 16  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -185,20 +232,24 @@ public getDiagnosingClinician (void)
 **Description**
 
 ```php
-public getDiagnosisClassification (void)
+public getDiagnosisClassification (int $position)
 ```
 
- 
+Get Diagnosis Classification (OBR.17) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 17  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -208,7 +259,7 @@ public getDiagnosisClassification (void)
 **Description**
 
 ```php
-public getDiagnosisCodeDG1 (void)
+ getDiagnosisCodeDG1 (void)
 ```
 
  
@@ -222,6 +273,7 @@ public getDiagnosisCodeDG1 (void)
 **Return Values**
 
 `void`
+
 
 <hr />
 
@@ -231,20 +283,24 @@ public getDiagnosisCodeDG1 (void)
 **Description**
 
 ```php
-public getDiagnosisCodingMethod (void)
+public getDiagnosisCodingMethod (int $position)
 ```
 
- 
+Get Diagnosis CodingMethod (OBR.2) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 2  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -254,20 +310,24 @@ public getDiagnosisCodingMethod (void)
 **Description**
 
 ```php
-public getDiagnosisDateTime (void)
+public getDiagnosisDateTime (int $position)
 ```
 
- 
+Get Diagnosis DateTime (OBR.5) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 5  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -277,20 +337,24 @@ public getDiagnosisDateTime (void)
 **Description**
 
 ```php
-public getDiagnosisDescription (void)
+public getDiagnosisDescription (int $position)
 ```
 
- 
+Get Diagnosis Description (OBR.4) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 4  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -300,20 +364,24 @@ public getDiagnosisDescription (void)
 **Description**
 
 ```php
-public getDiagnosisPriority (void)
+public getDiagnosisPriority (int $position)
 ```
 
- 
+Get Diagnosis Priority (OBR.15) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 15  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -323,20 +391,24 @@ public getDiagnosisPriority (void)
 **Description**
 
 ```php
-public getDiagnosisType (void)
+public getDiagnosisType (int $position)
 ```
 
- 
+Get Diagnosis Type (OBR.6) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 6  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -346,20 +418,24 @@ public getDiagnosisType (void)
 **Description**
 
 ```php
-public getDiagnosticRelatedGroup (void)
+public getDiagnosticRelatedGroup (int $position)
 ```
 
- 
+Get Diagnostic RelatedGroup (OBR.8) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 8  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -369,20 +445,24 @@ public getDiagnosticRelatedGroup (void)
 **Description**
 
 ```php
-public getGrouperVersionAndType (void)
+public getGrouperVersionAndType (int $position)
 ```
 
- 
+Get Grouper VersionAndType (OBR.14) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 14  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -392,20 +472,24 @@ public getGrouperVersionAndType (void)
 **Description**
 
 ```php
-public getID (void)
+public getID (int $position)
 ```
 
- 
+Get ID (OBR.1) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 1  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -415,20 +499,24 @@ public getID (void)
 **Description**
 
 ```php
-public getMajorDiagnosticCategory (void)
+public getMajorDiagnosticCategory (int $position)
 ```
 
- 
+Get Major DiagnosticCategory (OBR.7) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 7  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -438,20 +526,24 @@ public getMajorDiagnosticCategory (void)
 **Description**
 
 ```php
-public getOutlierCost (void)
+public getOutlierCost (int $position)
 ```
 
- 
+Get Outlier Cost (OBR.13) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 13  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -461,20 +553,24 @@ public getOutlierCost (void)
 **Description**
 
 ```php
-public getOutlierDays (void)
+public getOutlierDays (int $position)
 ```
 
- 
+Get Outlier Days (OBR.12) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 12  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -484,10 +580,37 @@ public getOutlierDays (void)
 **Description**
 
 ```php
-public getOutlierType (void)
+public getOutlierType (int $position)
 ```
 
+Get Outlier Type (OBR.11) 
+
  
+
+**Parameters**
+
+* `(int) $position`
+: Defaults to 11  
+
+**Return Values**
+
+`array|string|int|null`
+
+
+
+
+<hr />
+
+
+### DG1::resetIndex  
+
+**Description**
+
+```php
+public static resetIndex (void)
+```
+
+Reset index of this segment 
 
  
 
@@ -498,6 +621,7 @@ public getOutlierType (void)
 **Return Values**
 
 `void`
+
 
 <hr />
 
@@ -507,20 +631,25 @@ public getOutlierType (void)
 **Description**
 
 ```php
-public setAttestationDateTime (void)
+public setAttestationDateTime (string|int|array|null $value, int $position)
 ```
 
- 
+Set Attestation DateTime (OBR.19) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 19  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -530,20 +659,25 @@ public setAttestationDateTime (void)
 **Description**
 
 ```php
-public setConfidentialIndicator (void)
+public setConfidentialIndicator (string|int|array|null $value, int $position)
 ```
 
- 
+Set Confidential Indicator (OBR.18) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 18  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -553,20 +687,25 @@ public setConfidentialIndicator (void)
 **Description**
 
 ```php
-public setDRGApprovalIndicator (void)
+public setDRGApprovalIndicator (string|int|array|null $value, int $position)
 ```
 
- 
+Set DRGApproval Indicator (OBR.9) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 9  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -576,20 +715,25 @@ public setDRGApprovalIndicator (void)
 **Description**
 
 ```php
-public setDRGGrouperReviewCode (void)
+public setDRGGrouperReviewCode (string|int|array|null $value, int $position)
 ```
 
- 
+Set DRGGrouper ReviewCode (OBR.10) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 10  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -599,20 +743,25 @@ public setDRGGrouperReviewCode (void)
 **Description**
 
 ```php
-public setDiagnosingClinician (void)
+public setDiagnosingClinician (string|int|array|null $value, int $position)
 ```
 
- 
+Set Diagnosing Clinician (OBR.16) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 16  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -622,20 +771,25 @@ public setDiagnosingClinician (void)
 **Description**
 
 ```php
-public setDiagnosisClassification (void)
+public setDiagnosisClassification (string|int|array|null $value, int $position)
 ```
 
- 
+Set Diagnosis Classification (OBR.17) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 17  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -645,7 +799,7 @@ public setDiagnosisClassification (void)
 **Description**
 
 ```php
-public setDiagnosisCodeDG1 (void)
+ setDiagnosisCodeDG1 (void)
 ```
 
  
@@ -659,6 +813,7 @@ public setDiagnosisCodeDG1 (void)
 **Return Values**
 
 `void`
+
 
 <hr />
 
@@ -668,20 +823,25 @@ public setDiagnosisCodeDG1 (void)
 **Description**
 
 ```php
-public setDiagnosisCodingMethod (void)
+public setDiagnosisCodingMethod (string|int|array|null $value, int $position)
 ```
 
- 
+Set Diagnosis CodingMethod (OBR.2) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 2  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -691,20 +851,25 @@ public setDiagnosisCodingMethod (void)
 **Description**
 
 ```php
-public setDiagnosisDateTime (void)
+public setDiagnosisDateTime (string|int|array|null $value, int $position)
 ```
 
- 
+Set Diagnosis DateTime (OBR.5) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 5  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -714,20 +879,25 @@ public setDiagnosisDateTime (void)
 **Description**
 
 ```php
-public setDiagnosisDescription (void)
+public setDiagnosisDescription (string|int|array|null $value, int $position)
 ```
 
- 
+Set Diagnosis Description (OBR.4) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 4  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -737,20 +907,25 @@ public setDiagnosisDescription (void)
 **Description**
 
 ```php
-public setDiagnosisPriority (void)
+public setDiagnosisPriority (string|int|array|null $value, int $position)
 ```
 
- 
+Set Diagnosis Priority (OBR.15) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 15  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -760,20 +935,25 @@ public setDiagnosisPriority (void)
 **Description**
 
 ```php
-public setDiagnosisType (void)
+public setDiagnosisType (string|int|array|null $value, int $position)
 ```
 
- 
+Set Diagnosis Type (OBR.6) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 6  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -783,20 +963,25 @@ public setDiagnosisType (void)
 **Description**
 
 ```php
-public setDiagnosticRelatedGroup (void)
+public setDiagnosticRelatedGroup (string|int|array|null $value, int $position)
 ```
 
- 
+Set Diagnostic RelatedGroup (OBR.8) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 8  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -806,20 +991,25 @@ public setDiagnosticRelatedGroup (void)
 **Description**
 
 ```php
-public setGrouperVersionAndType (void)
+public setGrouperVersionAndType (string|int|array|null $value, int $position)
 ```
 
- 
+Set Grouper VersionAndType (OBR.14) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 14  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -829,7 +1019,7 @@ public setGrouperVersionAndType (void)
 **Description**
 
 ```php
-public setID (void)
+ setID (void)
 ```
 
  
@@ -843,6 +1033,7 @@ public setID (void)
 **Return Values**
 
 `void`
+
 
 <hr />
 
@@ -852,20 +1043,25 @@ public setID (void)
 **Description**
 
 ```php
-public setMajorDiagnosticCategory (void)
+public setMajorDiagnosticCategory (string|int|array|null $value, int $position)
 ```
 
- 
+Set Major DiagnosticCategory (OBR.7) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 7  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -875,20 +1071,25 @@ public setMajorDiagnosticCategory (void)
 **Description**
 
 ```php
-public setOutlierCost (void)
+public setOutlierCost (string|int|array|null $value, int $position)
 ```
 
- 
+Set Outlier Cost (OBR.13) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 13  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -898,20 +1099,25 @@ public setOutlierCost (void)
 **Description**
 
 ```php
-public setOutlierDays (void)
+public setOutlierDays (string|int|array|null $value, int $position)
 ```
 
- 
+Set Outlier Days (OBR.12) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 12  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -921,20 +1127,25 @@ public setOutlierDays (void)
 **Description**
 
 ```php
-public setOutlierType (void)
+public setOutlierType (string|int|array|null $value, int $position)
 ```
 
- 
+Set Outlier Type (OBR.11) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 11  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 

--- a/docs/Segments/EQU.md
+++ b/docs/Segments/EQU.md
@@ -13,23 +13,24 @@ Aranyasen\HL7\Segment
 
 | Name | Description |
 |------|-------------|
-|[getAlertLevel](#equgetalertlevel)||
-|[getEquipmentInstanceIdentifier](#equgetequipmentinstanceidentifier)||
-|[getEquipmentState](#equgetequipmentstate)||
-|[getEventDateTime](#equgeteventdatetime)||
-|[getLocalRemoteControlState](#equgetlocalremotecontrolstate)||
+|[getAlertLevel](#equgetalertlevel)|Get Alert Level (OBR.4)|
+|[getEquipmentInstanceIdentifier](#equgetequipmentinstanceidentifier)|Get Equipment InstanceIdentifier (OBR.1)|
+|[getEquipmentState](#equgetequipmentstate)|Get Equipment State (OBR.3)|
+|[getEventDateTime](#equgeteventdatetime)|Get Event DateTime (OBR.2)|
+|[getLocalRemoteControlState](#equgetlocalremotecontrolstate)|Get Local RemoteControlState (OBR.4)|
 |[resetIndex](#equresetindex)|Reset index of this segment|
-|[setAlertLevel](#equsetalertlevel)||
+|[setAlertLevel](#equsetalertlevel)|Set Alert Level (OBR.5)|
 |[setEquipmentInstanceIdentifier](#equsetequipmentinstanceidentifier)||
-|[setEquipmentState](#equsetequipmentstate)||
-|[setEventDateTime](#equseteventdatetime)||
-|[setLocalRemoteControlState](#equsetlocalremotecontrolstate)||
+|[setEquipmentState](#equsetequipmentstate)|Set Equipment State (OBR.3)|
+|[setEventDateTime](#equseteventdatetime)|Set Event DateTime (OBR.2)|
+|[setLocalRemoteControlState](#equsetlocalremotecontrolstate)|Set Local RemoteControlState (OBR.4)|
 
 ## Inherited methods
 
 | Name | Description |
 |------|-------------|
 |__construct|Create a segment.|
+|clearField|Remove any existing value from the field|
 |getField|Get the field at index.|
 |getFields|Get fields from a segment|
 |getName|Get the name of the segment. This is basically the value at index 0|
@@ -43,20 +44,23 @@ Aranyasen\HL7\Segment
 **Description**
 
 ```php
- getAlertLevel (void)
+public getAlertLevel (int $position)
 ```
 
- 
+Get Alert Level (OBR.4) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 4  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
 
 
 <hr />
@@ -67,20 +71,23 @@ Aranyasen\HL7\Segment
 **Description**
 
 ```php
- getEquipmentInstanceIdentifier (void)
+public getEquipmentInstanceIdentifier (int $position)
 ```
 
- 
+Get Equipment InstanceIdentifier (OBR.1) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 1  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
 
 
 <hr />
@@ -91,20 +98,23 @@ Aranyasen\HL7\Segment
 **Description**
 
 ```php
- getEquipmentState (void)
+public getEquipmentState (int $position)
 ```
 
- 
+Get Equipment State (OBR.3) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 3  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
 
 
 <hr />
@@ -115,20 +125,23 @@ Aranyasen\HL7\Segment
 **Description**
 
 ```php
- getEventDateTime (void)
+public getEventDateTime (int $position)
 ```
 
- 
+Get Event DateTime (OBR.2) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 2  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
 
 
 <hr />
@@ -139,20 +152,23 @@ Aranyasen\HL7\Segment
 **Description**
 
 ```php
- getLocalRemoteControlState (void)
+public getLocalRemoteControlState (int $position)
 ```
 
- 
+Get Local RemoteControlState (OBR.4) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 4  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
 
 
 <hr />
@@ -163,7 +179,7 @@ Aranyasen\HL7\Segment
 **Description**
 
 ```php
-public static resetIndex (int $index)
+public static resetIndex (void)
 ```
 
 Reset index of this segment 
@@ -172,7 +188,7 @@ Reset index of this segment
 
 **Parameters**
 
-* `(int) $index`
+`This function has no parameters.`
 
 **Return Values**
 
@@ -187,20 +203,24 @@ Reset index of this segment
 **Description**
 
 ```php
- setAlertLevel (void)
+public setAlertLevel (string|int|array|null $value, int $position)
 ```
 
- 
+Set Alert Level (OBR.5) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 5  
 
 **Return Values**
 
-`void`
+`bool`
+
+
 
 
 <hr />
@@ -235,20 +255,24 @@ Reset index of this segment
 **Description**
 
 ```php
- setEquipmentState (void)
+public setEquipmentState (string|int|array|null $value, int $position)
 ```
 
- 
+Set Equipment State (OBR.3) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 3  
 
 **Return Values**
 
-`void`
+`bool`
+
+
 
 
 <hr />
@@ -259,20 +283,24 @@ Reset index of this segment
 **Description**
 
 ```php
- setEventDateTime (void)
+public setEventDateTime (string|int|array|null $value, int $position)
 ```
 
- 
+Set Event DateTime (OBR.2) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 2  
 
 **Return Values**
 
-`void`
+`bool`
+
+
 
 
 <hr />
@@ -283,20 +311,24 @@ Reset index of this segment
 **Description**
 
 ```php
- setLocalRemoteControlState (void)
+public setLocalRemoteControlState (string|int|array|null $value, int $position)
 ```
 
- 
+Set Local RemoteControlState (OBR.4) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 4  
 
 **Return Values**
 
-`void`
+`bool`
+
+
 
 
 <hr />

--- a/docs/Segments/EVN.md
+++ b/docs/Segments/EVN.md
@@ -1,0 +1,372 @@
+# Aranyasen\HL7\Segments\EVN  
+
+EVN segment class
+Ref: http://hl7-definition.caristix.com:9010/HL7%20v2.3.1/segment/EVN
+     https://corepointhealth.com/resource-center/hl7-resources/hl7-evn-event-type-segment
+
+
+
+## Extend:
+
+Aranyasen\HL7\Segment
+
+## Methods
+
+| Name | Description |
+|------|-------------|
+|[getDateTimePlannedEvent](#evngetdatetimeplannedevent)|Get Date TimePlannedEvent (OBR.3)|
+|[getEventOccurred](#evngeteventoccurred)|Get Event Occurred (OBR.6)|
+|[getEventReasonCode](#evngeteventreasoncode)|Get Event ReasonCode (OBR.4)|
+|[getEventTypeCode](#evngeteventtypecode)|Get Event TypeCode (OBR.1)|
+|[getOperatorID](#evngetoperatorid)|Get Operator ID (OBR.5)|
+|[getRecordedDateTime](#evngetrecordeddatetime)|Get Recorded DateTime (OBR.2)|
+|[setDateTimePlannedEvent](#evnsetdatetimeplannedevent)|Set Date TimePlannedEvent (OBR.3)|
+|[setEventOccurred](#evnseteventoccurred)|Set Event Occurred (OBR.6)|
+|[setEventReasonCode](#evnseteventreasoncode)|Set Event ReasonCode (OBR.4)|
+|[setEventTypeCode](#evnseteventtypecode)|Set Event TypeCode (OBR.1)|
+|[setOperatorID](#evnsetoperatorid)|Set Operator ID (OBR.5)|
+|[setRecordedDateTime](#evnsetrecordeddatetime)|Set Recorded DateTime (OBR.2)|
+
+## Inherited methods
+
+| Name | Description |
+|------|-------------|
+|__construct|Create a segment.|
+|clearField|Remove any existing value from the field|
+|getField|Get the field at index.|
+|getFields|Get fields from a segment|
+|getName|Get the name of the segment. This is basically the value at index 0|
+|setField|Set the field specified by index to value.|
+|size|Get the number of fields for this segment, not including the name|
+
+
+
+### EVN::getDateTimePlannedEvent  
+
+**Description**
+
+```php
+public getDateTimePlannedEvent (int $position)
+```
+
+Get Date TimePlannedEvent (OBR.3) 
+
+ 
+
+**Parameters**
+
+* `(int) $position`
+: Defaults to 3  
+
+**Return Values**
+
+`array|string|int|null`
+
+
+
+
+<hr />
+
+
+### EVN::getEventOccurred  
+
+**Description**
+
+```php
+public getEventOccurred (int $position)
+```
+
+Get Event Occurred (OBR.6) 
+
+ 
+
+**Parameters**
+
+* `(int) $position`
+: Defaults to 6  
+
+**Return Values**
+
+`array|string|int|null`
+
+
+
+
+<hr />
+
+
+### EVN::getEventReasonCode  
+
+**Description**
+
+```php
+public getEventReasonCode (int $position)
+```
+
+Get Event ReasonCode (OBR.4) 
+
+ 
+
+**Parameters**
+
+* `(int) $position`
+: Defaults to 4  
+
+**Return Values**
+
+`array|string|int|null`
+
+
+
+
+<hr />
+
+
+### EVN::getEventTypeCode  
+
+**Description**
+
+```php
+public getEventTypeCode (int $position)
+```
+
+Get Event TypeCode (OBR.1) 
+
+ 
+
+**Parameters**
+
+* `(int) $position`
+: Defaults to 1  
+
+**Return Values**
+
+`array|string|int|null`
+
+
+
+
+<hr />
+
+
+### EVN::getOperatorID  
+
+**Description**
+
+```php
+public getOperatorID (int $position)
+```
+
+Get Operator ID (OBR.5) 
+
+ 
+
+**Parameters**
+
+* `(int) $position`
+: Defaults to 5  
+
+**Return Values**
+
+`array|string|int|null`
+
+
+
+
+<hr />
+
+
+### EVN::getRecordedDateTime  
+
+**Description**
+
+```php
+public getRecordedDateTime (int $position)
+```
+
+Get Recorded DateTime (OBR.2) 
+
+ 
+
+**Parameters**
+
+* `(int) $position`
+: Defaults to 2  
+
+**Return Values**
+
+`array|string|int|null`
+
+
+
+
+<hr />
+
+
+### EVN::setDateTimePlannedEvent  
+
+**Description**
+
+```php
+public setDateTimePlannedEvent (string|int|array|null $value, int $position)
+```
+
+Set Date TimePlannedEvent (OBR.3) 
+
+ 
+
+**Parameters**
+
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 3  
+
+**Return Values**
+
+`bool`
+
+
+
+
+<hr />
+
+
+### EVN::setEventOccurred  
+
+**Description**
+
+```php
+public setEventOccurred (string|int|array|null $value, int $position)
+```
+
+Set Event Occurred (OBR.6) 
+
+ 
+
+**Parameters**
+
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 6  
+
+**Return Values**
+
+`bool`
+
+
+
+
+<hr />
+
+
+### EVN::setEventReasonCode  
+
+**Description**
+
+```php
+public setEventReasonCode (string|int|array|null $value, int $position)
+```
+
+Set Event ReasonCode (OBR.4) 
+
+ 
+
+**Parameters**
+
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 4  
+
+**Return Values**
+
+`bool`
+
+
+
+
+<hr />
+
+
+### EVN::setEventTypeCode  
+
+**Description**
+
+```php
+public setEventTypeCode (string|int|array|null $value, int $position)
+```
+
+Set Event TypeCode (OBR.1) 
+
+ 
+
+**Parameters**
+
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 1  
+
+**Return Values**
+
+`bool`
+
+
+
+
+<hr />
+
+
+### EVN::setOperatorID  
+
+**Description**
+
+```php
+public setOperatorID (string|int|array|null $value, int $position)
+```
+
+Set Operator ID (OBR.5) 
+
+ 
+
+**Parameters**
+
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 5  
+
+**Return Values**
+
+`bool`
+
+
+
+
+<hr />
+
+
+### EVN::setRecordedDateTime  
+
+**Description**
+
+```php
+public setRecordedDateTime (string|int|array|null $value, int $position)
+```
+
+Set Recorded DateTime (OBR.2) 
+
+ 
+
+**Parameters**
+
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 2  
+
+**Return Values**
+
+`bool`
+
+
+
+
+<hr />
+

--- a/docs/Segments/IN1.md
+++ b/docs/Segments/IN1.md
@@ -13,110 +13,113 @@ Aranyasen\HL7\Segment
 
 | Name | Description |
 |------|-------------|
-|[getAssignmentOfBenefits](#in1getassignmentofbenefits)||
-|[getAuthorizationInformation](#in1getauthorizationinformation)||
-|[getBillingStatus](#in1getbillingstatus)||
-|[getCompanyPlanCode](#in1getcompanyplancode)||
-|[getCoordOfBenPriority](#in1getcoordofbenpriority)||
-|[getCoordinationOfBenefits](#in1getcoordinationofbenefits)||
-|[getCoverageType](#in1getcoveragetype)||
-|[getDelayBeforeLRDay](#in1getdelaybeforelrday)||
-|[getGroupName](#in1getgroupname)||
-|[getGroupNumber](#in1getgroupnumber)||
-|[getHandicap](#in1gethandicap)||
-|[getID](#in1getid)||
-|[getInsuranceCoContactPerson](#in1getinsurancecocontactperson)||
-|[getInsuranceCoPhoneNumber](#in1getinsurancecophonenumber)||
-|[getInsuranceCompanyAddress](#in1getinsurancecompanyaddress)||
-|[getInsuranceCompanyID](#in1getinsurancecompanyid)||
-|[getInsuranceCompanyName](#in1getinsurancecompanyname)||
-|[getInsurancePlanID](#in1getinsuranceplanid)||
-|[getInsuredsAddress](#in1getinsuredsaddress)||
-|[getInsuredsDateOfBirth](#in1getinsuredsdateofbirth)||
-|[getInsuredsEmployersAddress](#in1getinsuredsemployersaddress)||
-|[getInsuredsEmploymentStatus](#in1getinsuredsemploymentstatus)||
-|[getInsuredsGroupEmpID](#in1getinsuredsgroupempid)||
-|[getInsuredsGroupEmpName](#in1getinsuredsgroupempname)||
-|[getInsuredsIDNumber](#in1getinsuredsidnumber)||
-|[getInsuredsRelationshipToPatient](#in1getinsuredsrelationshiptopatient)||
-|[getInsuredsSex](#in1getinsuredssex)||
-|[getLifetimeReserveDays](#in1getlifetimereservedays)||
-|[getNameOfInsured](#in1getnameofinsured)||
-|[getNoticeOfAdmissionDate](#in1getnoticeofadmissiondate)||
-|[getNoticeOfAdmissionFlag](#in1getnoticeofadmissionflag)||
-|[getPlanEffectiveDate](#in1getplaneffectivedate)||
-|[getPlanExpirationDate](#in1getplanexpirationdate)||
-|[getPlanType](#in1getplantype)||
-|[getPolicyDeductible](#in1getpolicydeductible)||
-|[getPolicyLimitAmount](#in1getpolicylimitamount)||
-|[getPolicyLimitDays](#in1getpolicylimitdays)||
-|[getPolicyNumber](#in1getpolicynumber)||
-|[getPreAdmitCertPAC](#in1getpreadmitcertpac)||
-|[getPriorInsurancePlanID](#in1getpriorinsuranceplanid)||
-|[getReleaseInformationCode](#in1getreleaseinformationcode)||
-|[getReportOfEligibilityDate](#in1getreportofeligibilitydate)||
-|[getReportOfEligibilityFlag](#in1getreportofeligibilityflag)||
-|[getRoomRatePrivate](#in1getroomrateprivate)||
-|[getRoomRateSemiPrivate](#in1getroomratesemiprivate)||
-|[getTypeOfAgreementCode](#in1gettypeofagreementcode)||
-|[getVerificationBy](#in1getverificationby)||
-|[getVerificationDateTime](#in1getverificationdatetime)||
-|[getVerificationStatus](#in1getverificationstatus)||
-|[setAssignmentOfBenefits](#in1setassignmentofbenefits)||
-|[setAuthorizationInformation](#in1setauthorizationinformation)||
-|[setBillingStatus](#in1setbillingstatus)||
-|[setCompanyPlanCode](#in1setcompanyplancode)||
-|[setCoordOfBenPriority](#in1setcoordofbenpriority)||
-|[setCoordinationOfBenefits](#in1setcoordinationofbenefits)||
-|[setCoverageType](#in1setcoveragetype)||
-|[setDelayBeforeLRDay](#in1setdelaybeforelrday)||
-|[setGroupName](#in1setgroupname)||
-|[setGroupNumber](#in1setgroupnumber)||
-|[setHandicap](#in1sethandicap)||
+|[__destruct](#in1__destruct)||
+|[getAssignmentOfBenefits](#in1getassignmentofbenefits)|Get Assignment OfBenefits (OBR.20)|
+|[getAuthorizationInformation](#in1getauthorizationinformation)|Get Authorization Information (OBR.14)|
+|[getBillingStatus](#in1getbillingstatus)|Get Billing Status (OBR.32)|
+|[getCompanyPlanCode](#in1getcompanyplancode)|Get Company PlanCode (OBR.35)|
+|[getCoordOfBenPriority](#in1getcoordofbenpriority)|Get Coord OfBenPriority (OBR.22)|
+|[getCoordinationOfBenefits](#in1getcoordinationofbenefits)|Get Coordination OfBenefits (OBR.21)|
+|[getCoverageType](#in1getcoveragetype)|Get Coverage Type (OBR.47)|
+|[getDelayBeforeLRDay](#in1getdelaybeforelrday)|Get Delay BeforeLRDay (OBR.34)|
+|[getGroupName](#in1getgroupname)|Get Group Name (OBR.9)|
+|[getGroupNumber](#in1getgroupnumber)|Get Group Number (OBR.8)|
+|[getHandicap](#in1gethandicap)|Get Handicap (OBR.48)|
+|[getID](#in1getid)|Get ID (OBR.1)|
+|[getInsuranceCoContactPerson](#in1getinsurancecocontactperson)|Get Insurance CoContactPerson (OBR.6)|
+|[getInsuranceCoPhoneNumber](#in1getinsurancecophonenumber)|Get Insurance CoPhoneNumber (OBR.7)|
+|[getInsuranceCompanyAddress](#in1getinsurancecompanyaddress)|Get Insurance CompanyAddress (OBR.5)|
+|[getInsuranceCompanyID](#in1getinsurancecompanyid)|Get Insurance CompanyID (OBR.3)|
+|[getInsuranceCompanyName](#in1getinsurancecompanyname)|Get Insurance CompanyName (OBR.4)|
+|[getInsurancePlanID](#in1getinsuranceplanid)|Get Insurance PlanID (OBR.2)|
+|[getInsuredsAddress](#in1getinsuredsaddress)|Get Insureds Address (OBR.19)|
+|[getInsuredsDateOfBirth](#in1getinsuredsdateofbirth)|Get Insureds DateOfBirth (OBR.18)|
+|[getInsuredsEmployersAddress](#in1getinsuredsemployersaddress)|Get Insureds EmployersAddress (OBR.44)|
+|[getInsuredsEmploymentStatus](#in1getinsuredsemploymentstatus)|Get Insureds EmploymentStatus (OBR.42)|
+|[getInsuredsGroupEmpID](#in1getinsuredsgroupempid)|Get Insureds GroupEmpID (OBR.10)|
+|[getInsuredsGroupEmpName](#in1getinsuredsgroupempname)|Get Insureds GroupEmpName (OBR.11)|
+|[getInsuredsIDNumber](#in1getinsuredsidnumber)|Get Insureds IDNumber (OBR.49)|
+|[getInsuredsRelationshipToPatient](#in1getinsuredsrelationshiptopatient)|Get Insureds RelationshipToPatient (OBR.17)|
+|[getInsuredsSex](#in1getinsuredssex)|Get Insureds Sex (OBR.43)|
+|[getLifetimeReserveDays](#in1getlifetimereservedays)|Get Lifetime ReserveDays (OBR.33)|
+|[getNameOfInsured](#in1getnameofinsured)|Get Name OfInsured (OBR.16)|
+|[getNoticeOfAdmissionDate](#in1getnoticeofadmissiondate)|Get Notice OfAdmissionDate (OBR.24)|
+|[getNoticeOfAdmissionFlag](#in1getnoticeofadmissionflag)|Get Notice OfAdmissionFlag (OBR.23)|
+|[getPlanEffectiveDate](#in1getplaneffectivedate)|Get Plan EffectiveDate (OBR.12)|
+|[getPlanExpirationDate](#in1getplanexpirationdate)|Get Plan ExpirationDate (OBR.13)|
+|[getPlanType](#in1getplantype)|Get Plan Type (OBR.15)|
+|[getPolicyDeductible](#in1getpolicydeductible)|Get Policy Deductible (OBR.37)|
+|[getPolicyLimitAmount](#in1getpolicylimitamount)|Get Policy LimitAmount (OBR.38)|
+|[getPolicyLimitDays](#in1getpolicylimitdays)|Get Policy LimitDays (OBR.39)|
+|[getPolicyNumber](#in1getpolicynumber)|Get Policy Number (OBR.36)|
+|[getPreAdmitCertPAC](#in1getpreadmitcertpac)|Get Pre AdmitCertPAC (OBR.28)|
+|[getPriorInsurancePlanID](#in1getpriorinsuranceplanid)|Get Prior InsurancePlanID (OBR.46)|
+|[getReleaseInformationCode](#in1getreleaseinformationcode)|Get Release InformationCode (OBR.27)|
+|[getReportOfEligibilityDate](#in1getreportofeligibilitydate)|Get Report OfEligibilityDate (OBR.26)|
+|[getReportOfEligibilityFlag](#in1getreportofeligibilityflag)|Get Report OfEligibilityFlag (OBR.25)|
+|[getRoomRatePrivate](#in1getroomrateprivate)|Get Room RatePrivate (OBR.41)|
+|[getRoomRateSemiPrivate](#in1getroomratesemiprivate)|Get Room RateSemiPrivate (OBR.40)|
+|[getTypeOfAgreementCode](#in1gettypeofagreementcode)|Get Type OfAgreementCode (OBR.31)|
+|[getVerificationBy](#in1getverificationby)|Get Verification By (OBR.30)|
+|[getVerificationDateTime](#in1getverificationdatetime)|Get Verification DateTime (OBR.29)|
+|[getVerificationStatus](#in1getverificationstatus)|Get Verification Status (OBR.45)|
+|[resetIndex](#in1resetindex)|Reset index of this segment|
+|[setAssignmentOfBenefits](#in1setassignmentofbenefits)|Set Assignment OfBenefits (OBR.20)|
+|[setAuthorizationInformation](#in1setauthorizationinformation)|Set Authorization Information (OBR.14)|
+|[setBillingStatus](#in1setbillingstatus)|Set Billing Status (OBR.32)|
+|[setCompanyPlanCode](#in1setcompanyplancode)|Set Company PlanCode (OBR.35)|
+|[setCoordOfBenPriority](#in1setcoordofbenpriority)|Set Coord OfBenPriority (OBR.22)|
+|[setCoordinationOfBenefits](#in1setcoordinationofbenefits)|Set Coordination OfBenefits (OBR.21)|
+|[setCoverageType](#in1setcoveragetype)|Set Coverage Type (OBR.47)|
+|[setDelayBeforeLRDay](#in1setdelaybeforelrday)|Set Delay BeforeLRDay (OBR.34)|
+|[setGroupName](#in1setgroupname)|Set Group Name (OBR.9)|
+|[setGroupNumber](#in1setgroupnumber)|Set Group Number (OBR.8)|
+|[setHandicap](#in1sethandicap)|Set Handicap (OBR.48)|
 |[setID](#in1setid)||
-|[setInsuranceCoContactPerson](#in1setinsurancecocontactperson)||
-|[setInsuranceCoPhoneNumber](#in1setinsurancecophonenumber)||
-|[setInsuranceCompanyAddress](#in1setinsurancecompanyaddress)||
-|[setInsuranceCompanyID](#in1setinsurancecompanyid)||
-|[setInsuranceCompanyName](#in1setinsurancecompanyname)||
-|[setInsurancePlanID](#in1setinsuranceplanid)||
-|[setInsuredsAddress](#in1setinsuredsaddress)||
-|[setInsuredsDateOfBirth](#in1setinsuredsdateofbirth)||
-|[setInsuredsEmployersAddress](#in1setinsuredsemployersaddress)||
-|[setInsuredsEmploymentStatus](#in1setinsuredsemploymentstatus)||
-|[setInsuredsGroupEmpID](#in1setinsuredsgroupempid)||
-|[setInsuredsGroupEmpName](#in1setinsuredsgroupempname)||
-|[setInsuredsIDNumber](#in1setinsuredsidnumber)||
-|[setInsuredsRelationshipToPatient](#in1setinsuredsrelationshiptopatient)||
-|[setInsuredsSex](#in1setinsuredssex)||
-|[setLifetimeReserveDays](#in1setlifetimereservedays)||
-|[setNameOfInsured](#in1setnameofinsured)||
-|[setNoticeOfAdmissionDate](#in1setnoticeofadmissiondate)||
-|[setNoticeOfAdmissionFlag](#in1setnoticeofadmissionflag)||
-|[setPlanEffectiveDate](#in1setplaneffectivedate)||
-|[setPlanExpirationDate](#in1setplanexpirationdate)||
-|[setPlanType](#in1setplantype)||
-|[setPolicyDeductible](#in1setpolicydeductible)||
-|[setPolicyLimitAmount](#in1setpolicylimitamount)||
-|[setPolicyLimitDays](#in1setpolicylimitdays)||
-|[setPolicyNumber](#in1setpolicynumber)||
-|[setPreAdmitCertPAC](#in1setpreadmitcertpac)||
-|[setPriorInsurancePlanID](#in1setpriorinsuranceplanid)||
-|[setReleaseInformationCode](#in1setreleaseinformationcode)||
-|[setReportOfEligibilityDate](#in1setreportofeligibilitydate)||
-|[setReportOfEligibilityFlag](#in1setreportofeligibilityflag)||
-|[setRoomRatePrivate](#in1setroomrateprivate)||
-|[setRoomRateSemiPrivate](#in1setroomratesemiprivate)||
-|[setTypeOfAgreementCode](#in1settypeofagreementcode)||
-|[setVerificationBy](#in1setverificationby)||
-|[setVerificationDateTime](#in1setverificationdatetime)||
-|[setVerificationStatus](#in1setverificationstatus)||
+|[setInsuranceCoContactPerson](#in1setinsurancecocontactperson)|Set Insurance CoContactPerson (OBR.6)|
+|[setInsuranceCoPhoneNumber](#in1setinsurancecophonenumber)|Set Insurance CoPhoneNumber (OBR.7)|
+|[setInsuranceCompanyAddress](#in1setinsurancecompanyaddress)|Set Insurance CompanyAddress (OBR.5)|
+|[setInsuranceCompanyID](#in1setinsurancecompanyid)|Set Insurance CompanyID (OBR.3)|
+|[setInsuranceCompanyName](#in1setinsurancecompanyname)|Set Insurance CompanyName (OBR.4)|
+|[setInsurancePlanID](#in1setinsuranceplanid)|Set Insurance PlanID (OBR.2)|
+|[setInsuredsAddress](#in1setinsuredsaddress)|Set Insureds Address (OBR.19)|
+|[setInsuredsDateOfBirth](#in1setinsuredsdateofbirth)|Set Insureds DateOfBirth (OBR.18)|
+|[setInsuredsEmployersAddress](#in1setinsuredsemployersaddress)|Set Insureds EmployersAddress (OBR.44)|
+|[setInsuredsEmploymentStatus](#in1setinsuredsemploymentstatus)|Set Insureds EmploymentStatus (OBR.42)|
+|[setInsuredsGroupEmpID](#in1setinsuredsgroupempid)|Set Insureds GroupEmpID (OBR.10)|
+|[setInsuredsGroupEmpName](#in1setinsuredsgroupempname)|Set Insureds GroupEmpName (OBR.11)|
+|[setInsuredsIDNumber](#in1setinsuredsidnumber)|Set Insureds IDNumber (OBR.49)|
+|[setInsuredsRelationshipToPatient](#in1setinsuredsrelationshiptopatient)|Set Insureds RelationshipToPatient (OBR.17)|
+|[setInsuredsSex](#in1setinsuredssex)|Set Insureds Sex (OBR.43)|
+|[setLifetimeReserveDays](#in1setlifetimereservedays)|Set Lifetime ReserveDays (OBR.33)|
+|[setNameOfInsured](#in1setnameofinsured)|Set Name OfInsured (OBR.16)|
+|[setNoticeOfAdmissionDate](#in1setnoticeofadmissiondate)|Set Notice OfAdmissionDate (OBR.24)|
+|[setNoticeOfAdmissionFlag](#in1setnoticeofadmissionflag)|Set Notice OfAdmissionFlag (OBR.23)|
+|[setPlanEffectiveDate](#in1setplaneffectivedate)|Set Plan EffectiveDate (OBR.12)|
+|[setPlanExpirationDate](#in1setplanexpirationdate)|Set Plan ExpirationDate (OBR.13)|
+|[setPlanType](#in1setplantype)|Set Plan Type (OBR.15)|
+|[setPolicyDeductible](#in1setpolicydeductible)|Set Policy Deductible (OBR.37)|
+|[setPolicyLimitAmount](#in1setpolicylimitamount)|Set Policy LimitAmount (OBR.38)|
+|[setPolicyLimitDays](#in1setpolicylimitdays)|Set Policy LimitDays (OBR.39)|
+|[setPolicyNumber](#in1setpolicynumber)|Set Policy Number (OBR.36)|
+|[setPreAdmitCertPAC](#in1setpreadmitcertpac)|Set Pre AdmitCertPAC (OBR.28)|
+|[setPriorInsurancePlanID](#in1setpriorinsuranceplanid)|Set Prior InsurancePlanID (OBR.46)|
+|[setReleaseInformationCode](#in1setreleaseinformationcode)|Set Release InformationCode (OBR.27)|
+|[setReportOfEligibilityDate](#in1setreportofeligibilitydate)|Set Report OfEligibilityDate (OBR.26)|
+|[setReportOfEligibilityFlag](#in1setreportofeligibilityflag)|Set Report OfEligibilityFlag (OBR.25)|
+|[setRoomRatePrivate](#in1setroomrateprivate)|Set Room RatePrivate (OBR.41)|
+|[setRoomRateSemiPrivate](#in1setroomratesemiprivate)|Set Room RateSemiPrivate (OBR.40)|
+|[setTypeOfAgreementCode](#in1settypeofagreementcode)|Set Type OfAgreementCode (OBR.31)|
+|[setVerificationBy](#in1setverificationby)|Set Verification By (OBR.30)|
+|[setVerificationDateTime](#in1setverificationdatetime)|Set Verification DateTime (OBR.29)|
+|[setVerificationStatus](#in1setverificationstatus)|Set Verification Status (OBR.45)|
 
 ## Inherited methods
 
 | Name | Description |
 |------|-------------|
 |__construct|Create a segment.|
+|clearField|Remove any existing value from the field|
 |getField|Get the field at index.|
 |getFields|Get fields from a segment|
 |getName|Get the name of the segment. This is basically the value at index 0|
@@ -125,12 +128,12 @@ Aranyasen\HL7\Segment
 
 
 
-### IN1::getAssignmentOfBenefits  
+### IN1::__destruct  
 
 **Description**
 
 ```php
-public getAssignmentOfBenefits (void)
+ __destruct (void)
 ```
 
  
@@ -144,6 +147,34 @@ public getAssignmentOfBenefits (void)
 **Return Values**
 
 `void`
+
+
+<hr />
+
+
+### IN1::getAssignmentOfBenefits  
+
+**Description**
+
+```php
+public getAssignmentOfBenefits (int $position)
+```
+
+Get Assignment OfBenefits (OBR.20) 
+
+ 
+
+**Parameters**
+
+* `(int) $position`
+: Defaults to 20  
+
+**Return Values**
+
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -153,20 +184,24 @@ public getAssignmentOfBenefits (void)
 **Description**
 
 ```php
-public getAuthorizationInformation (void)
+public getAuthorizationInformation (int $position)
 ```
 
- 
+Get Authorization Information (OBR.14) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 14  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -176,20 +211,24 @@ public getAuthorizationInformation (void)
 **Description**
 
 ```php
-public getBillingStatus (void)
+public getBillingStatus (int $position)
 ```
 
- 
+Get Billing Status (OBR.32) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 32  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -199,20 +238,24 @@ public getBillingStatus (void)
 **Description**
 
 ```php
-public getCompanyPlanCode (void)
+public getCompanyPlanCode (int $position)
 ```
 
- 
+Get Company PlanCode (OBR.35) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 35  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -222,20 +265,24 @@ public getCompanyPlanCode (void)
 **Description**
 
 ```php
-public getCoordOfBenPriority (void)
+public getCoordOfBenPriority (int $position)
 ```
 
- 
+Get Coord OfBenPriority (OBR.22) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 22  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -245,20 +292,24 @@ public getCoordOfBenPriority (void)
 **Description**
 
 ```php
-public getCoordinationOfBenefits (void)
+public getCoordinationOfBenefits (int $position)
 ```
 
- 
+Get Coordination OfBenefits (OBR.21) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 21  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -268,20 +319,24 @@ public getCoordinationOfBenefits (void)
 **Description**
 
 ```php
-public getCoverageType (void)
+public getCoverageType (int $position)
 ```
 
- 
+Get Coverage Type (OBR.47) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 47  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -291,20 +346,24 @@ public getCoverageType (void)
 **Description**
 
 ```php
-public getDelayBeforeLRDay (void)
+public getDelayBeforeLRDay (int $position)
 ```
 
- 
+Get Delay BeforeLRDay (OBR.34) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 34  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -314,20 +373,24 @@ public getDelayBeforeLRDay (void)
 **Description**
 
 ```php
-public getGroupName (void)
+public getGroupName (int $position)
 ```
 
- 
+Get Group Name (OBR.9) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 9  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -337,20 +400,24 @@ public getGroupName (void)
 **Description**
 
 ```php
-public getGroupNumber (void)
+public getGroupNumber (int $position)
 ```
 
- 
+Get Group Number (OBR.8) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 8  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -360,20 +427,24 @@ public getGroupNumber (void)
 **Description**
 
 ```php
-public getHandicap (void)
+public getHandicap (int $position)
 ```
 
- 
+Get Handicap (OBR.48) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 48  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -383,20 +454,24 @@ public getHandicap (void)
 **Description**
 
 ```php
-public getID (void)
+public getID (int $position)
 ```
 
- 
+Get ID (OBR.1) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 1  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -406,20 +481,24 @@ public getID (void)
 **Description**
 
 ```php
-public getInsuranceCoContactPerson (void)
+public getInsuranceCoContactPerson (int $position)
 ```
 
- 
+Get Insurance CoContactPerson (OBR.6) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 6  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -429,20 +508,24 @@ public getInsuranceCoContactPerson (void)
 **Description**
 
 ```php
-public getInsuranceCoPhoneNumber (void)
+public getInsuranceCoPhoneNumber (int $position)
 ```
 
- 
+Get Insurance CoPhoneNumber (OBR.7) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 7  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -452,20 +535,24 @@ public getInsuranceCoPhoneNumber (void)
 **Description**
 
 ```php
-public getInsuranceCompanyAddress (void)
+public getInsuranceCompanyAddress (int $position)
 ```
 
- 
+Get Insurance CompanyAddress (OBR.5) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 5  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -475,20 +562,24 @@ public getInsuranceCompanyAddress (void)
 **Description**
 
 ```php
-public getInsuranceCompanyID (void)
+public getInsuranceCompanyID (int $position)
 ```
 
- 
+Get Insurance CompanyID (OBR.3) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 3  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -498,20 +589,24 @@ public getInsuranceCompanyID (void)
 **Description**
 
 ```php
-public getInsuranceCompanyName (void)
+public getInsuranceCompanyName (int $position)
 ```
 
- 
+Get Insurance CompanyName (OBR.4) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 4  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -521,20 +616,24 @@ public getInsuranceCompanyName (void)
 **Description**
 
 ```php
-public getInsurancePlanID (void)
+public getInsurancePlanID (int $position)
 ```
 
- 
+Get Insurance PlanID (OBR.2) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 2  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -544,20 +643,24 @@ public getInsurancePlanID (void)
 **Description**
 
 ```php
-public getInsuredsAddress (void)
+public getInsuredsAddress (int $position)
 ```
 
- 
+Get Insureds Address (OBR.19) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 19  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -567,20 +670,24 @@ public getInsuredsAddress (void)
 **Description**
 
 ```php
-public getInsuredsDateOfBirth (void)
+public getInsuredsDateOfBirth (int $position)
 ```
 
- 
+Get Insureds DateOfBirth (OBR.18) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 18  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -590,20 +697,24 @@ public getInsuredsDateOfBirth (void)
 **Description**
 
 ```php
-public getInsuredsEmployersAddress (void)
+public getInsuredsEmployersAddress (int $position)
 ```
 
- 
+Get Insureds EmployersAddress (OBR.44) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 44  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -613,20 +724,24 @@ public getInsuredsEmployersAddress (void)
 **Description**
 
 ```php
-public getInsuredsEmploymentStatus (void)
+public getInsuredsEmploymentStatus (int $position)
 ```
 
- 
+Get Insureds EmploymentStatus (OBR.42) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 42  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -636,20 +751,24 @@ public getInsuredsEmploymentStatus (void)
 **Description**
 
 ```php
-public getInsuredsGroupEmpID (void)
+public getInsuredsGroupEmpID (int $position)
 ```
 
- 
+Get Insureds GroupEmpID (OBR.10) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 10  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -659,20 +778,24 @@ public getInsuredsGroupEmpID (void)
 **Description**
 
 ```php
-public getInsuredsGroupEmpName (void)
+public getInsuredsGroupEmpName (int $position)
 ```
 
- 
+Get Insureds GroupEmpName (OBR.11) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 11  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -682,20 +805,24 @@ public getInsuredsGroupEmpName (void)
 **Description**
 
 ```php
-public getInsuredsIDNumber (void)
+public getInsuredsIDNumber (int $position)
 ```
 
- 
+Get Insureds IDNumber (OBR.49) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 49  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -705,20 +832,24 @@ public getInsuredsIDNumber (void)
 **Description**
 
 ```php
-public getInsuredsRelationshipToPatient (void)
+public getInsuredsRelationshipToPatient (int $position)
 ```
 
- 
+Get Insureds RelationshipToPatient (OBR.17) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 17  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -728,20 +859,24 @@ public getInsuredsRelationshipToPatient (void)
 **Description**
 
 ```php
-public getInsuredsSex (void)
+public getInsuredsSex (int $position)
 ```
 
- 
+Get Insureds Sex (OBR.43) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 43  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -751,20 +886,24 @@ public getInsuredsSex (void)
 **Description**
 
 ```php
-public getLifetimeReserveDays (void)
+public getLifetimeReserveDays (int $position)
 ```
 
- 
+Get Lifetime ReserveDays (OBR.33) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 33  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -774,20 +913,24 @@ public getLifetimeReserveDays (void)
 **Description**
 
 ```php
-public getNameOfInsured (void)
+public getNameOfInsured (int $position)
 ```
 
- 
+Get Name OfInsured (OBR.16) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 16  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -797,20 +940,24 @@ public getNameOfInsured (void)
 **Description**
 
 ```php
-public getNoticeOfAdmissionDate (void)
+public getNoticeOfAdmissionDate (int $position)
 ```
 
- 
+Get Notice OfAdmissionDate (OBR.24) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 24  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -820,20 +967,24 @@ public getNoticeOfAdmissionDate (void)
 **Description**
 
 ```php
-public getNoticeOfAdmissionFlag (void)
+public getNoticeOfAdmissionFlag (int $position)
 ```
 
- 
+Get Notice OfAdmissionFlag (OBR.23) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 23  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -843,20 +994,24 @@ public getNoticeOfAdmissionFlag (void)
 **Description**
 
 ```php
-public getPlanEffectiveDate (void)
+public getPlanEffectiveDate (int $position)
 ```
 
- 
+Get Plan EffectiveDate (OBR.12) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 12  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -866,20 +1021,24 @@ public getPlanEffectiveDate (void)
 **Description**
 
 ```php
-public getPlanExpirationDate (void)
+public getPlanExpirationDate (int $position)
 ```
 
- 
+Get Plan ExpirationDate (OBR.13) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 13  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -889,20 +1048,24 @@ public getPlanExpirationDate (void)
 **Description**
 
 ```php
-public getPlanType (void)
+public getPlanType (int $position)
 ```
 
- 
+Get Plan Type (OBR.15) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 15  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -912,20 +1075,24 @@ public getPlanType (void)
 **Description**
 
 ```php
-public getPolicyDeductible (void)
+public getPolicyDeductible (int $position)
 ```
 
- 
+Get Policy Deductible (OBR.37) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 37  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -935,20 +1102,24 @@ public getPolicyDeductible (void)
 **Description**
 
 ```php
-public getPolicyLimitAmount (void)
+public getPolicyLimitAmount (int $position)
 ```
 
- 
+Get Policy LimitAmount (OBR.38) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 38  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -958,20 +1129,24 @@ public getPolicyLimitAmount (void)
 **Description**
 
 ```php
-public getPolicyLimitDays (void)
+public getPolicyLimitDays (int $position)
 ```
 
- 
+Get Policy LimitDays (OBR.39) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 39  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -981,20 +1156,24 @@ public getPolicyLimitDays (void)
 **Description**
 
 ```php
-public getPolicyNumber (void)
+public getPolicyNumber (int $position)
 ```
 
- 
+Get Policy Number (OBR.36) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 36  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -1004,20 +1183,24 @@ public getPolicyNumber (void)
 **Description**
 
 ```php
-public getPreAdmitCertPAC (void)
+public getPreAdmitCertPAC (int $position)
 ```
 
- 
+Get Pre AdmitCertPAC (OBR.28) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 28  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -1027,20 +1210,24 @@ public getPreAdmitCertPAC (void)
 **Description**
 
 ```php
-public getPriorInsurancePlanID (void)
+public getPriorInsurancePlanID (int $position)
 ```
 
- 
+Get Prior InsurancePlanID (OBR.46) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 46  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -1050,20 +1237,24 @@ public getPriorInsurancePlanID (void)
 **Description**
 
 ```php
-public getReleaseInformationCode (void)
+public getReleaseInformationCode (int $position)
 ```
 
- 
+Get Release InformationCode (OBR.27) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 27  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -1073,20 +1264,24 @@ public getReleaseInformationCode (void)
 **Description**
 
 ```php
-public getReportOfEligibilityDate (void)
+public getReportOfEligibilityDate (int $position)
 ```
 
- 
+Get Report OfEligibilityDate (OBR.26) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 26  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -1096,20 +1291,24 @@ public getReportOfEligibilityDate (void)
 **Description**
 
 ```php
-public getReportOfEligibilityFlag (void)
+public getReportOfEligibilityFlag (int $position)
 ```
 
- 
+Get Report OfEligibilityFlag (OBR.25) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 25  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -1119,20 +1318,24 @@ public getReportOfEligibilityFlag (void)
 **Description**
 
 ```php
-public getRoomRatePrivate (void)
+public getRoomRatePrivate (int $position)
 ```
 
- 
+Get Room RatePrivate (OBR.41) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 41  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -1142,20 +1345,24 @@ public getRoomRatePrivate (void)
 **Description**
 
 ```php
-public getRoomRateSemiPrivate (void)
+public getRoomRateSemiPrivate (int $position)
 ```
 
- 
+Get Room RateSemiPrivate (OBR.40) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 40  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -1165,20 +1372,24 @@ public getRoomRateSemiPrivate (void)
 **Description**
 
 ```php
-public getTypeOfAgreementCode (void)
+public getTypeOfAgreementCode (int $position)
 ```
 
- 
+Get Type OfAgreementCode (OBR.31) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 31  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -1188,20 +1399,24 @@ public getTypeOfAgreementCode (void)
 **Description**
 
 ```php
-public getVerificationBy (void)
+public getVerificationBy (int $position)
 ```
 
- 
+Get Verification By (OBR.30) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 30  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -1211,20 +1426,24 @@ public getVerificationBy (void)
 **Description**
 
 ```php
-public getVerificationDateTime (void)
+public getVerificationDateTime (int $position)
 ```
 
- 
+Get Verification DateTime (OBR.29) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 29  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -1234,10 +1453,37 @@ public getVerificationDateTime (void)
 **Description**
 
 ```php
-public getVerificationStatus (void)
+public getVerificationStatus (int $position)
 ```
 
+Get Verification Status (OBR.45) 
+
  
+
+**Parameters**
+
+* `(int) $position`
+: Defaults to 45  
+
+**Return Values**
+
+`array|string|int|null`
+
+
+
+
+<hr />
+
+
+### IN1::resetIndex  
+
+**Description**
+
+```php
+public static resetIndex (void)
+```
+
+Reset index of this segment 
 
  
 
@@ -1248,6 +1494,7 @@ public getVerificationStatus (void)
 **Return Values**
 
 `void`
+
 
 <hr />
 
@@ -1257,20 +1504,25 @@ public getVerificationStatus (void)
 **Description**
 
 ```php
-public setAssignmentOfBenefits (void)
+public setAssignmentOfBenefits (string|int|array|null $value, int $position)
 ```
 
- 
+Set Assignment OfBenefits (OBR.20) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 20  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1280,20 +1532,25 @@ public setAssignmentOfBenefits (void)
 **Description**
 
 ```php
-public setAuthorizationInformation (void)
+public setAuthorizationInformation (string|int|array|null $value, int $position)
 ```
 
- 
+Set Authorization Information (OBR.14) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 14  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1303,20 +1560,25 @@ public setAuthorizationInformation (void)
 **Description**
 
 ```php
-public setBillingStatus (void)
+public setBillingStatus (string|int|array|null $value, int $position)
 ```
 
- 
+Set Billing Status (OBR.32) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 32  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1326,20 +1588,25 @@ public setBillingStatus (void)
 **Description**
 
 ```php
-public setCompanyPlanCode (void)
+public setCompanyPlanCode (string|int|array|null $value, int $position)
 ```
 
- 
+Set Company PlanCode (OBR.35) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 35  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1349,20 +1616,25 @@ public setCompanyPlanCode (void)
 **Description**
 
 ```php
-public setCoordOfBenPriority (void)
+public setCoordOfBenPriority (string|int|array|null $value, int $position)
 ```
 
- 
+Set Coord OfBenPriority (OBR.22) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 22  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1372,20 +1644,25 @@ public setCoordOfBenPriority (void)
 **Description**
 
 ```php
-public setCoordinationOfBenefits (void)
+public setCoordinationOfBenefits (string|int|array|null $value, int $position)
 ```
 
- 
+Set Coordination OfBenefits (OBR.21) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 21  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1395,20 +1672,25 @@ public setCoordinationOfBenefits (void)
 **Description**
 
 ```php
-public setCoverageType (void)
+public setCoverageType (string|int|array|null $value, int $position)
 ```
 
- 
+Set Coverage Type (OBR.47) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 47  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1418,20 +1700,25 @@ public setCoverageType (void)
 **Description**
 
 ```php
-public setDelayBeforeLRDay (void)
+public setDelayBeforeLRDay (string|int|array|null $value, int $position)
 ```
 
- 
+Set Delay BeforeLRDay (OBR.34) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 34  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1441,20 +1728,25 @@ public setDelayBeforeLRDay (void)
 **Description**
 
 ```php
-public setGroupName (void)
+public setGroupName (string|int|array|null $value, int $position)
 ```
 
- 
+Set Group Name (OBR.9) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 9  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1464,20 +1756,25 @@ public setGroupName (void)
 **Description**
 
 ```php
-public setGroupNumber (void)
+public setGroupNumber (string|int|array|null $value, int $position)
 ```
 
- 
+Set Group Number (OBR.8) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 8  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1487,20 +1784,25 @@ public setGroupNumber (void)
 **Description**
 
 ```php
-public setHandicap (void)
+public setHandicap (string|int|array|null $value, int $position)
 ```
 
- 
+Set Handicap (OBR.48) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 48  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1510,7 +1812,7 @@ public setHandicap (void)
 **Description**
 
 ```php
-public setID (void)
+ setID (void)
 ```
 
  
@@ -1524,6 +1826,7 @@ public setID (void)
 **Return Values**
 
 `void`
+
 
 <hr />
 
@@ -1533,20 +1836,25 @@ public setID (void)
 **Description**
 
 ```php
-public setInsuranceCoContactPerson (void)
+public setInsuranceCoContactPerson (string|int|array|null $value, int $position)
 ```
 
- 
+Set Insurance CoContactPerson (OBR.6) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 6  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1556,20 +1864,25 @@ public setInsuranceCoContactPerson (void)
 **Description**
 
 ```php
-public setInsuranceCoPhoneNumber (void)
+public setInsuranceCoPhoneNumber (string|int|array|null $value, int $position)
 ```
 
- 
+Set Insurance CoPhoneNumber (OBR.7) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 7  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1579,20 +1892,25 @@ public setInsuranceCoPhoneNumber (void)
 **Description**
 
 ```php
-public setInsuranceCompanyAddress (void)
+public setInsuranceCompanyAddress (string|int|array|null $value, int $position)
 ```
 
- 
+Set Insurance CompanyAddress (OBR.5) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 5  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1602,20 +1920,25 @@ public setInsuranceCompanyAddress (void)
 **Description**
 
 ```php
-public setInsuranceCompanyID (void)
+public setInsuranceCompanyID (string|int|array|null $value, int $position)
 ```
 
- 
+Set Insurance CompanyID (OBR.3) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 3  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1625,20 +1948,25 @@ public setInsuranceCompanyID (void)
 **Description**
 
 ```php
-public setInsuranceCompanyName (void)
+public setInsuranceCompanyName (string|int|array|null $value, int $position)
 ```
 
- 
+Set Insurance CompanyName (OBR.4) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 4  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1648,20 +1976,25 @@ public setInsuranceCompanyName (void)
 **Description**
 
 ```php
-public setInsurancePlanID (void)
+public setInsurancePlanID (string|int|array|null $value, int $position)
 ```
 
- 
+Set Insurance PlanID (OBR.2) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 2  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1671,20 +2004,25 @@ public setInsurancePlanID (void)
 **Description**
 
 ```php
-public setInsuredsAddress (void)
+public setInsuredsAddress (string|int|array|null $value, int $position)
 ```
 
- 
+Set Insureds Address (OBR.19) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 19  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1694,20 +2032,25 @@ public setInsuredsAddress (void)
 **Description**
 
 ```php
-public setInsuredsDateOfBirth (void)
+public setInsuredsDateOfBirth (string|int|array|null $value, int $position)
 ```
 
- 
+Set Insureds DateOfBirth (OBR.18) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 18  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1717,20 +2060,25 @@ public setInsuredsDateOfBirth (void)
 **Description**
 
 ```php
-public setInsuredsEmployersAddress (void)
+public setInsuredsEmployersAddress (string|int|array|null $value, int $position)
 ```
 
- 
+Set Insureds EmployersAddress (OBR.44) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 44  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1740,20 +2088,25 @@ public setInsuredsEmployersAddress (void)
 **Description**
 
 ```php
-public setInsuredsEmploymentStatus (void)
+public setInsuredsEmploymentStatus (string|int|array|null $value, int $position)
 ```
 
- 
+Set Insureds EmploymentStatus (OBR.42) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 42  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1763,20 +2116,25 @@ public setInsuredsEmploymentStatus (void)
 **Description**
 
 ```php
-public setInsuredsGroupEmpID (void)
+public setInsuredsGroupEmpID (string|int|array|null $value, int $position)
 ```
 
- 
+Set Insureds GroupEmpID (OBR.10) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 10  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1786,20 +2144,25 @@ public setInsuredsGroupEmpID (void)
 **Description**
 
 ```php
-public setInsuredsGroupEmpName (void)
+public setInsuredsGroupEmpName (string|int|array|null $value, int $position)
 ```
 
- 
+Set Insureds GroupEmpName (OBR.11) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 11  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1809,20 +2172,25 @@ public setInsuredsGroupEmpName (void)
 **Description**
 
 ```php
-public setInsuredsIDNumber (void)
+public setInsuredsIDNumber (string|int|array|null $value, int $position)
 ```
 
- 
+Set Insureds IDNumber (OBR.49) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 49  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1832,20 +2200,25 @@ public setInsuredsIDNumber (void)
 **Description**
 
 ```php
-public setInsuredsRelationshipToPatient (void)
+public setInsuredsRelationshipToPatient (string|int|array|null $value, int $position)
 ```
 
- 
+Set Insureds RelationshipToPatient (OBR.17) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 17  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1855,20 +2228,25 @@ public setInsuredsRelationshipToPatient (void)
 **Description**
 
 ```php
-public setInsuredsSex (void)
+public setInsuredsSex (string|int|array|null $value, int $position)
 ```
 
- 
+Set Insureds Sex (OBR.43) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 43  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1878,20 +2256,25 @@ public setInsuredsSex (void)
 **Description**
 
 ```php
-public setLifetimeReserveDays (void)
+public setLifetimeReserveDays (string|int|array|null $value, int $position)
 ```
 
- 
+Set Lifetime ReserveDays (OBR.33) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 33  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1901,20 +2284,25 @@ public setLifetimeReserveDays (void)
 **Description**
 
 ```php
-public setNameOfInsured (void)
+public setNameOfInsured (string|int|array|null $value, int $position)
 ```
 
- 
+Set Name OfInsured (OBR.16) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 16  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1924,20 +2312,25 @@ public setNameOfInsured (void)
 **Description**
 
 ```php
-public setNoticeOfAdmissionDate (void)
+public setNoticeOfAdmissionDate (string|int|array|null $value, int $position)
 ```
 
- 
+Set Notice OfAdmissionDate (OBR.24) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 24  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1947,20 +2340,25 @@ public setNoticeOfAdmissionDate (void)
 **Description**
 
 ```php
-public setNoticeOfAdmissionFlag (void)
+public setNoticeOfAdmissionFlag (string|int|array|null $value, int $position)
 ```
 
- 
+Set Notice OfAdmissionFlag (OBR.23) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 23  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1970,20 +2368,25 @@ public setNoticeOfAdmissionFlag (void)
 **Description**
 
 ```php
-public setPlanEffectiveDate (void)
+public setPlanEffectiveDate (string|int|array|null $value, int $position)
 ```
 
- 
+Set Plan EffectiveDate (OBR.12) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 12  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1993,20 +2396,25 @@ public setPlanEffectiveDate (void)
 **Description**
 
 ```php
-public setPlanExpirationDate (void)
+public setPlanExpirationDate (string|int|array|null $value, int $position)
 ```
 
- 
+Set Plan ExpirationDate (OBR.13) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 13  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -2016,20 +2424,25 @@ public setPlanExpirationDate (void)
 **Description**
 
 ```php
-public setPlanType (void)
+public setPlanType (string|int|array|null $value, int $position)
 ```
 
- 
+Set Plan Type (OBR.15) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 15  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -2039,20 +2452,25 @@ public setPlanType (void)
 **Description**
 
 ```php
-public setPolicyDeductible (void)
+public setPolicyDeductible (string|int|array|null $value, int $position)
 ```
 
- 
+Set Policy Deductible (OBR.37) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 37  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -2062,20 +2480,25 @@ public setPolicyDeductible (void)
 **Description**
 
 ```php
-public setPolicyLimitAmount (void)
+public setPolicyLimitAmount (string|int|array|null $value, int $position)
 ```
 
- 
+Set Policy LimitAmount (OBR.38) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 38  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -2085,20 +2508,25 @@ public setPolicyLimitAmount (void)
 **Description**
 
 ```php
-public setPolicyLimitDays (void)
+public setPolicyLimitDays (string|int|array|null $value, int $position)
 ```
 
- 
+Set Policy LimitDays (OBR.39) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 39  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -2108,20 +2536,25 @@ public setPolicyLimitDays (void)
 **Description**
 
 ```php
-public setPolicyNumber (void)
+public setPolicyNumber (string|int|array|null $value, int $position)
 ```
 
- 
+Set Policy Number (OBR.36) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 36  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -2131,20 +2564,25 @@ public setPolicyNumber (void)
 **Description**
 
 ```php
-public setPreAdmitCertPAC (void)
+public setPreAdmitCertPAC (string|int|array|null $value, int $position)
 ```
 
- 
+Set Pre AdmitCertPAC (OBR.28) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 28  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -2154,20 +2592,25 @@ public setPreAdmitCertPAC (void)
 **Description**
 
 ```php
-public setPriorInsurancePlanID (void)
+public setPriorInsurancePlanID (string|int|array|null $value, int $position)
 ```
 
- 
+Set Prior InsurancePlanID (OBR.46) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 46  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -2177,20 +2620,25 @@ public setPriorInsurancePlanID (void)
 **Description**
 
 ```php
-public setReleaseInformationCode (void)
+public setReleaseInformationCode (string|int|array|null $value, int $position)
 ```
 
- 
+Set Release InformationCode (OBR.27) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 27  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -2200,20 +2648,25 @@ public setReleaseInformationCode (void)
 **Description**
 
 ```php
-public setReportOfEligibilityDate (void)
+public setReportOfEligibilityDate (string|int|array|null $value, int $position)
 ```
 
- 
+Set Report OfEligibilityDate (OBR.26) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 26  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -2223,20 +2676,25 @@ public setReportOfEligibilityDate (void)
 **Description**
 
 ```php
-public setReportOfEligibilityFlag (void)
+public setReportOfEligibilityFlag (string|int|array|null $value, int $position)
 ```
 
- 
+Set Report OfEligibilityFlag (OBR.25) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 25  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -2246,20 +2704,25 @@ public setReportOfEligibilityFlag (void)
 **Description**
 
 ```php
-public setRoomRatePrivate (void)
+public setRoomRatePrivate (string|int|array|null $value, int $position)
 ```
 
- 
+Set Room RatePrivate (OBR.41) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 41  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -2269,20 +2732,25 @@ public setRoomRatePrivate (void)
 **Description**
 
 ```php
-public setRoomRateSemiPrivate (void)
+public setRoomRateSemiPrivate (string|int|array|null $value, int $position)
 ```
 
- 
+Set Room RateSemiPrivate (OBR.40) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 40  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -2292,20 +2760,25 @@ public setRoomRateSemiPrivate (void)
 **Description**
 
 ```php
-public setTypeOfAgreementCode (void)
+public setTypeOfAgreementCode (string|int|array|null $value, int $position)
 ```
 
- 
+Set Type OfAgreementCode (OBR.31) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 31  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -2315,20 +2788,25 @@ public setTypeOfAgreementCode (void)
 **Description**
 
 ```php
-public setVerificationBy (void)
+public setVerificationBy (string|int|array|null $value, int $position)
 ```
 
- 
+Set Verification By (OBR.30) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 30  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -2338,20 +2816,25 @@ public setVerificationBy (void)
 **Description**
 
 ```php
-public setVerificationDateTime (void)
+public setVerificationDateTime (string|int|array|null $value, int $position)
 ```
 
- 
+Set Verification DateTime (OBR.29) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 29  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -2361,20 +2844,25 @@ public setVerificationDateTime (void)
 **Description**
 
 ```php
-public setVerificationStatus (void)
+public setVerificationStatus (string|int|array|null $value, int $position)
 ```
 
- 
+Set Verification Status (OBR.45) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 45  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 

--- a/docs/Segments/IN3.md
+++ b/docs/Segments/IN3.md
@@ -13,62 +13,65 @@ Aranyasen\HL7\Segment
 
 | Name | Description |
 |------|-------------|
-|[getAppealReason](#in3getappealreason)||
-|[getCaseManager](#in3getcasemanager)||
-|[getCertificationAgency](#in3getcertificationagency)||
-|[getCertificationAgencyPhoneNumber](#in3getcertificationagencyphonenumber)||
-|[getCertificationBeginDate](#in3getcertificationbegindate)||
-|[getCertificationContact](#in3getcertificationcontact)||
-|[getCertificationContactPhoneNumber](#in3getcertificationcontactphonenumber)||
-|[getCertificationDateTime](#in3getcertificationdatetime)||
-|[getCertificationEndDate](#in3getcertificationenddate)||
-|[getCertificationModifyDateTime](#in3getcertificationmodifydatetime)||
-|[getCertificationNumber](#in3getcertificationnumber)||
-|[getCertificationRequired](#in3getcertificationrequired)||
-|[getCertifiedBy](#in3getcertifiedby)||
-|[getDays](#in3getdays)||
-|[getID](#in3getid)||
-|[getNonConcurCodeDescription](#in3getnonconcurcodedescription)||
-|[getNonConcurEffectiveDateTime](#in3getnonconcureffectivedatetime)||
-|[getOperator](#in3getoperator)||
-|[getPenalty](#in3getpenalty)||
-|[getPhysicianReviewer](#in3getphysicianreviewer)||
-|[getPreCertificationRequirement](#in3getprecertificationrequirement)||
-|[getSecondOpinionDate](#in3getsecondopiniondate)||
-|[getSecondOpinionDocumentationReceived](#in3getsecondopiniondocumentationreceived)||
-|[getSecondOpinionPhysician](#in3getsecondopinionphysician)||
-|[getSecondOpinionStatus](#in3getsecondopinionstatus)||
-|[setAppealReason](#in3setappealreason)||
-|[setCaseManager](#in3setcasemanager)||
-|[setCertificationAgency](#in3setcertificationagency)||
-|[setCertificationAgencyPhoneNumber](#in3setcertificationagencyphonenumber)||
-|[setCertificationBeginDate](#in3setcertificationbegindate)||
-|[setCertificationContact](#in3setcertificationcontact)||
-|[setCertificationContactPhoneNumber](#in3setcertificationcontactphonenumber)||
-|[setCertificationDateTime](#in3setcertificationdatetime)||
-|[setCertificationEndDate](#in3setcertificationenddate)||
-|[setCertificationModifyDateTime](#in3setcertificationmodifydatetime)||
-|[setCertificationNumber](#in3setcertificationnumber)||
-|[setCertificationRequired](#in3setcertificationrequired)||
-|[setCertifiedBy](#in3setcertifiedby)||
-|[setDays](#in3setdays)||
+|[__destruct](#in3__destruct)||
+|[getAppealReason](#in3getappealreason)|Get Appeal Reason (OBR.17)|
+|[getCaseManager](#in3getcasemanager)|Get Case Manager (OBR.21)|
+|[getCertificationAgency](#in3getcertificationagency)|Get Certification Agency (OBR.18)|
+|[getCertificationAgencyPhoneNumber](#in3getcertificationagencyphonenumber)|Get Certification AgencyPhoneNumber (OBR.19)|
+|[getCertificationBeginDate](#in3getcertificationbegindate)|Get Certification BeginDate (OBR.9)|
+|[getCertificationContact](#in3getcertificationcontact)|Get Certification Contact (OBR.15)|
+|[getCertificationContactPhoneNumber](#in3getcertificationcontactphonenumber)|Get Certification ContactPhoneNumber (OBR.16)|
+|[getCertificationDateTime](#in3getcertificationdatetime)|Get Certification DateTime (OBR.6)|
+|[getCertificationEndDate](#in3getcertificationenddate)|Get Certification EndDate (OBR.10)|
+|[getCertificationModifyDateTime](#in3getcertificationmodifydatetime)|Get Certification ModifyDateTime (OBR.7)|
+|[getCertificationNumber](#in3getcertificationnumber)|Get Certification Number (OBR.2)|
+|[getCertificationRequired](#in3getcertificationrequired)|Get Certification Required (OBR.4)|
+|[getCertifiedBy](#in3getcertifiedby)|Get Certified By (OBR.3)|
+|[getDays](#in3getdays)|Get Days (OBR.11)|
+|[getID](#in3getid)|Get ID (OBR.1)|
+|[getNonConcurCodeDescription](#in3getnonconcurcodedescription)|Get Non ConcurCodeDescription (OBR.12)|
+|[getNonConcurEffectiveDateTime](#in3getnonconcureffectivedatetime)|Get Non ConcurEffectiveDateTime (OBR.13)|
+|[getOperator](#in3getoperator)|Get Operator (OBR.8)|
+|[getPenalty](#in3getpenalty)|Get Penalty (OBR.5)|
+|[getPhysicianReviewer](#in3getphysicianreviewer)|Get Physician Reviewer (OBR.14)|
+|[getPreCertificationRequirement](#in3getprecertificationrequirement)|Get Pre CertificationRequirement (OBR.20)|
+|[getSecondOpinionDate](#in3getsecondopiniondate)|Get Second OpinionDate (OBR.22)|
+|[getSecondOpinionDocumentationReceived](#in3getsecondopiniondocumentationreceived)|Get Second OpinionDocumentationReceived (OBR.24)|
+|[getSecondOpinionPhysician](#in3getsecondopinionphysician)|Get Second OpinionPhysician (OBR.25)|
+|[getSecondOpinionStatus](#in3getsecondopinionstatus)|Get Second OpinionStatus (OBR.23)|
+|[resetIndex](#in3resetindex)|Reset index of this segment|
+|[setAppealReason](#in3setappealreason)|Set Appeal Reason (OBR.17)|
+|[setCaseManager](#in3setcasemanager)|Set Case Manager (OBR.21)|
+|[setCertificationAgency](#in3setcertificationagency)|Set Certification Agency (OBR.18)|
+|[setCertificationAgencyPhoneNumber](#in3setcertificationagencyphonenumber)|Set Certification AgencyPhoneNumber (OBR.19)|
+|[setCertificationBeginDate](#in3setcertificationbegindate)|Set Certification BeginDate (OBR.9)|
+|[setCertificationContact](#in3setcertificationcontact)|Set Certification Contact (OBR.15)|
+|[setCertificationContactPhoneNumber](#in3setcertificationcontactphonenumber)|Set Certification ContactPhoneNumber (OBR.16)|
+|[setCertificationDateTime](#in3setcertificationdatetime)|Set Certification DateTime (OBR.6)|
+|[setCertificationEndDate](#in3setcertificationenddate)|Set Certification EndDate (OBR.10)|
+|[setCertificationModifyDateTime](#in3setcertificationmodifydatetime)|Set Certification ModifyDateTime (OBR.7)|
+|[setCertificationNumber](#in3setcertificationnumber)|Set Certification Number (OBR.2)|
+|[setCertificationRequired](#in3setcertificationrequired)|Set Certification Required (OBR.4)|
+|[setCertifiedBy](#in3setcertifiedby)|Set Certified By (OBR.3)|
+|[setDays](#in3setdays)|Set Days (OBR.11)|
 |[setID](#in3setid)||
-|[setNonConcurCodeDescription](#in3setnonconcurcodedescription)||
-|[setNonConcurEffectiveDateTime](#in3setnonconcureffectivedatetime)||
-|[setOperator](#in3setoperator)||
-|[setPenalty](#in3setpenalty)||
-|[setPhysicianReviewer](#in3setphysicianreviewer)||
-|[setPreCertificationRequirement](#in3setprecertificationrequirement)||
-|[setSecondOpinionDate](#in3setsecondopiniondate)||
-|[setSecondOpinionDocumentationReceived](#in3setsecondopiniondocumentationreceived)||
-|[setSecondOpinionPhysician](#in3setsecondopinionphysician)||
-|[setSecondOpinionStatus](#in3setsecondopinionstatus)||
+|[setNonConcurCodeDescription](#in3setnonconcurcodedescription)|Set Non ConcurCodeDescription (OBR.12)|
+|[setNonConcurEffectiveDateTime](#in3setnonconcureffectivedatetime)|Set Non ConcurEffectiveDateTime (OBR.13)|
+|[setOperator](#in3setoperator)|Set Operator (OBR.8)|
+|[setPenalty](#in3setpenalty)|Set Penalty (OBR.5)|
+|[setPhysicianReviewer](#in3setphysicianreviewer)|Set Physician Reviewer (OBR.14)|
+|[setPreCertificationRequirement](#in3setprecertificationrequirement)|Set Pre CertificationRequirement (OBR.20)|
+|[setSecondOpinionDate](#in3setsecondopiniondate)|Set Second OpinionDate (OBR.22)|
+|[setSecondOpinionDocumentationReceived](#in3setsecondopiniondocumentationreceived)|Set Second OpinionDocumentationReceived (OBR.24)|
+|[setSecondOpinionPhysician](#in3setsecondopinionphysician)|Set Second OpinionPhysician (OBR.25)|
+|[setSecondOpinionStatus](#in3setsecondopinionstatus)|Set Second OpinionStatus (OBR.23)|
 
 ## Inherited methods
 
 | Name | Description |
 |------|-------------|
 |__construct|Create a segment.|
+|clearField|Remove any existing value from the field|
 |getField|Get the field at index.|
 |getFields|Get fields from a segment|
 |getName|Get the name of the segment. This is basically the value at index 0|
@@ -77,12 +80,12 @@ Aranyasen\HL7\Segment
 
 
 
-### IN3::getAppealReason  
+### IN3::__destruct  
 
 **Description**
 
 ```php
-public getAppealReason (void)
+ __destruct (void)
 ```
 
  
@@ -96,6 +99,34 @@ public getAppealReason (void)
 **Return Values**
 
 `void`
+
+
+<hr />
+
+
+### IN3::getAppealReason  
+
+**Description**
+
+```php
+public getAppealReason (int $position)
+```
+
+Get Appeal Reason (OBR.17) 
+
+ 
+
+**Parameters**
+
+* `(int) $position`
+: Defaults to 17  
+
+**Return Values**
+
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -105,20 +136,24 @@ public getAppealReason (void)
 **Description**
 
 ```php
-public getCaseManager (void)
+public getCaseManager (int $position)
 ```
 
- 
+Get Case Manager (OBR.21) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 21  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -128,20 +163,24 @@ public getCaseManager (void)
 **Description**
 
 ```php
-public getCertificationAgency (void)
+public getCertificationAgency (int $position)
 ```
 
- 
+Get Certification Agency (OBR.18) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 18  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -151,20 +190,24 @@ public getCertificationAgency (void)
 **Description**
 
 ```php
-public getCertificationAgencyPhoneNumber (void)
+public getCertificationAgencyPhoneNumber (int $position)
 ```
 
- 
+Get Certification AgencyPhoneNumber (OBR.19) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 19  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -174,20 +217,24 @@ public getCertificationAgencyPhoneNumber (void)
 **Description**
 
 ```php
-public getCertificationBeginDate (void)
+public getCertificationBeginDate (int $position)
 ```
 
- 
+Get Certification BeginDate (OBR.9) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 9  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -197,20 +244,24 @@ public getCertificationBeginDate (void)
 **Description**
 
 ```php
-public getCertificationContact (void)
+public getCertificationContact (int $position)
 ```
 
- 
+Get Certification Contact (OBR.15) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 15  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -220,20 +271,24 @@ public getCertificationContact (void)
 **Description**
 
 ```php
-public getCertificationContactPhoneNumber (void)
+public getCertificationContactPhoneNumber (int $position)
 ```
 
- 
+Get Certification ContactPhoneNumber (OBR.16) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 16  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -243,20 +298,24 @@ public getCertificationContactPhoneNumber (void)
 **Description**
 
 ```php
-public getCertificationDateTime (void)
+public getCertificationDateTime (int $position)
 ```
 
- 
+Get Certification DateTime (OBR.6) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 6  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -266,20 +325,24 @@ public getCertificationDateTime (void)
 **Description**
 
 ```php
-public getCertificationEndDate (void)
+public getCertificationEndDate (int $position)
 ```
 
- 
+Get Certification EndDate (OBR.10) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 10  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -289,20 +352,24 @@ public getCertificationEndDate (void)
 **Description**
 
 ```php
-public getCertificationModifyDateTime (void)
+public getCertificationModifyDateTime (int $position)
 ```
 
- 
+Get Certification ModifyDateTime (OBR.7) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 7  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -312,20 +379,24 @@ public getCertificationModifyDateTime (void)
 **Description**
 
 ```php
-public getCertificationNumber (void)
+public getCertificationNumber (int $position)
 ```
 
- 
+Get Certification Number (OBR.2) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 2  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -335,20 +406,24 @@ public getCertificationNumber (void)
 **Description**
 
 ```php
-public getCertificationRequired (void)
+public getCertificationRequired (int $position)
 ```
 
- 
+Get Certification Required (OBR.4) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 4  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -358,20 +433,24 @@ public getCertificationRequired (void)
 **Description**
 
 ```php
-public getCertifiedBy (void)
+public getCertifiedBy (int $position)
 ```
 
- 
+Get Certified By (OBR.3) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 3  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -381,20 +460,24 @@ public getCertifiedBy (void)
 **Description**
 
 ```php
-public getDays (void)
+public getDays (int $position)
 ```
 
- 
+Get Days (OBR.11) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 11  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -404,20 +487,24 @@ public getDays (void)
 **Description**
 
 ```php
-public getID (void)
+public getID (int $position)
 ```
 
- 
+Get ID (OBR.1) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 1  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -427,20 +514,24 @@ public getID (void)
 **Description**
 
 ```php
-public getNonConcurCodeDescription (void)
+public getNonConcurCodeDescription (int $position)
 ```
 
- 
+Get Non ConcurCodeDescription (OBR.12) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 12  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -450,20 +541,24 @@ public getNonConcurCodeDescription (void)
 **Description**
 
 ```php
-public getNonConcurEffectiveDateTime (void)
+public getNonConcurEffectiveDateTime (int $position)
 ```
 
- 
+Get Non ConcurEffectiveDateTime (OBR.13) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 13  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -473,20 +568,24 @@ public getNonConcurEffectiveDateTime (void)
 **Description**
 
 ```php
-public getOperator (void)
+public getOperator (int $position)
 ```
 
- 
+Get Operator (OBR.8) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 8  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -496,20 +595,24 @@ public getOperator (void)
 **Description**
 
 ```php
-public getPenalty (void)
+public getPenalty (int $position)
 ```
 
- 
+Get Penalty (OBR.5) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 5  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -519,20 +622,24 @@ public getPenalty (void)
 **Description**
 
 ```php
-public getPhysicianReviewer (void)
+public getPhysicianReviewer (int $position)
 ```
 
- 
+Get Physician Reviewer (OBR.14) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 14  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -542,20 +649,24 @@ public getPhysicianReviewer (void)
 **Description**
 
 ```php
-public getPreCertificationRequirement (void)
+public getPreCertificationRequirement (int $position)
 ```
 
- 
+Get Pre CertificationRequirement (OBR.20) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 20  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -565,20 +676,24 @@ public getPreCertificationRequirement (void)
 **Description**
 
 ```php
-public getSecondOpinionDate (void)
+public getSecondOpinionDate (int $position)
 ```
 
- 
+Get Second OpinionDate (OBR.22) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 22  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -588,20 +703,24 @@ public getSecondOpinionDate (void)
 **Description**
 
 ```php
-public getSecondOpinionDocumentationReceived (void)
+public getSecondOpinionDocumentationReceived (int $position)
 ```
 
- 
+Get Second OpinionDocumentationReceived (OBR.24) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 24  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -611,20 +730,24 @@ public getSecondOpinionDocumentationReceived (void)
 **Description**
 
 ```php
-public getSecondOpinionPhysician (void)
+public getSecondOpinionPhysician (int $position)
 ```
 
- 
+Get Second OpinionPhysician (OBR.25) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 25  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -634,10 +757,37 @@ public getSecondOpinionPhysician (void)
 **Description**
 
 ```php
-public getSecondOpinionStatus (void)
+public getSecondOpinionStatus (int $position)
 ```
 
+Get Second OpinionStatus (OBR.23) 
+
  
+
+**Parameters**
+
+* `(int) $position`
+: Defaults to 23  
+
+**Return Values**
+
+`array|string|int|null`
+
+
+
+
+<hr />
+
+
+### IN3::resetIndex  
+
+**Description**
+
+```php
+public static resetIndex (void)
+```
+
+Reset index of this segment 
 
  
 
@@ -648,6 +798,7 @@ public getSecondOpinionStatus (void)
 **Return Values**
 
 `void`
+
 
 <hr />
 
@@ -657,20 +808,25 @@ public getSecondOpinionStatus (void)
 **Description**
 
 ```php
-public setAppealReason (void)
+public setAppealReason (string|int|array|null $value, int $position)
 ```
 
- 
+Set Appeal Reason (OBR.17) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 17  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -680,20 +836,25 @@ public setAppealReason (void)
 **Description**
 
 ```php
-public setCaseManager (void)
+public setCaseManager (string|int|array|null $value, int $position)
 ```
 
- 
+Set Case Manager (OBR.21) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 21  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -703,20 +864,25 @@ public setCaseManager (void)
 **Description**
 
 ```php
-public setCertificationAgency (void)
+public setCertificationAgency (string|int|array|null $value, int $position)
 ```
 
- 
+Set Certification Agency (OBR.18) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 18  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -726,20 +892,25 @@ public setCertificationAgency (void)
 **Description**
 
 ```php
-public setCertificationAgencyPhoneNumber (void)
+public setCertificationAgencyPhoneNumber (string|int|array|null $value, int $position)
 ```
 
- 
+Set Certification AgencyPhoneNumber (OBR.19) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 19  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -749,20 +920,25 @@ public setCertificationAgencyPhoneNumber (void)
 **Description**
 
 ```php
-public setCertificationBeginDate (void)
+public setCertificationBeginDate (string|int|array|null $value, int $position)
 ```
 
- 
+Set Certification BeginDate (OBR.9) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 9  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -772,20 +948,25 @@ public setCertificationBeginDate (void)
 **Description**
 
 ```php
-public setCertificationContact (void)
+public setCertificationContact (string|int|array|null $value, int $position)
 ```
 
- 
+Set Certification Contact (OBR.15) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 15  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -795,20 +976,25 @@ public setCertificationContact (void)
 **Description**
 
 ```php
-public setCertificationContactPhoneNumber (void)
+public setCertificationContactPhoneNumber (string|int|array|null $value, int $position)
 ```
 
- 
+Set Certification ContactPhoneNumber (OBR.16) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 16  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -818,20 +1004,25 @@ public setCertificationContactPhoneNumber (void)
 **Description**
 
 ```php
-public setCertificationDateTime (void)
+public setCertificationDateTime (string|int|array|null $value, int $position)
 ```
 
- 
+Set Certification DateTime (OBR.6) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 6  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -841,20 +1032,25 @@ public setCertificationDateTime (void)
 **Description**
 
 ```php
-public setCertificationEndDate (void)
+public setCertificationEndDate (string|int|array|null $value, int $position)
 ```
 
- 
+Set Certification EndDate (OBR.10) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 10  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -864,20 +1060,25 @@ public setCertificationEndDate (void)
 **Description**
 
 ```php
-public setCertificationModifyDateTime (void)
+public setCertificationModifyDateTime (string|int|array|null $value, int $position)
 ```
 
- 
+Set Certification ModifyDateTime (OBR.7) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 7  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -887,20 +1088,25 @@ public setCertificationModifyDateTime (void)
 **Description**
 
 ```php
-public setCertificationNumber (void)
+public setCertificationNumber (string|int|array|null $value, int $position)
 ```
 
- 
+Set Certification Number (OBR.2) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 2  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -910,20 +1116,25 @@ public setCertificationNumber (void)
 **Description**
 
 ```php
-public setCertificationRequired (void)
+public setCertificationRequired (string|int|array|null $value, int $position)
 ```
 
- 
+Set Certification Required (OBR.4) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 4  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -933,20 +1144,25 @@ public setCertificationRequired (void)
 **Description**
 
 ```php
-public setCertifiedBy (void)
+public setCertifiedBy (string|int|array|null $value, int $position)
 ```
 
- 
+Set Certified By (OBR.3) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 3  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -956,20 +1172,25 @@ public setCertifiedBy (void)
 **Description**
 
 ```php
-public setDays (void)
+public setDays (string|int|array|null $value, int $position)
 ```
 
- 
+Set Days (OBR.11) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 11  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -979,7 +1200,7 @@ public setDays (void)
 **Description**
 
 ```php
-public setID (void)
+ setID (void)
 ```
 
  
@@ -993,6 +1214,7 @@ public setID (void)
 **Return Values**
 
 `void`
+
 
 <hr />
 
@@ -1002,20 +1224,25 @@ public setID (void)
 **Description**
 
 ```php
-public setNonConcurCodeDescription (void)
+public setNonConcurCodeDescription (string|int|array|null $value, int $position)
 ```
 
- 
+Set Non ConcurCodeDescription (OBR.12) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 12  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1025,20 +1252,25 @@ public setNonConcurCodeDescription (void)
 **Description**
 
 ```php
-public setNonConcurEffectiveDateTime (void)
+public setNonConcurEffectiveDateTime (string|int|array|null $value, int $position)
 ```
 
- 
+Set Non ConcurEffectiveDateTime (OBR.13) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 13  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1048,20 +1280,25 @@ public setNonConcurEffectiveDateTime (void)
 **Description**
 
 ```php
-public setOperator (void)
+public setOperator (string|int|array|null $value, int $position)
 ```
 
- 
+Set Operator (OBR.8) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 8  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1071,20 +1308,25 @@ public setOperator (void)
 **Description**
 
 ```php
-public setPenalty (void)
+public setPenalty (string|int|array|null $value, int $position)
 ```
 
- 
+Set Penalty (OBR.5) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 5  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1094,20 +1336,25 @@ public setPenalty (void)
 **Description**
 
 ```php
-public setPhysicianReviewer (void)
+public setPhysicianReviewer (string|int|array|null $value, int $position)
 ```
 
- 
+Set Physician Reviewer (OBR.14) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 14  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1117,20 +1364,25 @@ public setPhysicianReviewer (void)
 **Description**
 
 ```php
-public setPreCertificationRequirement (void)
+public setPreCertificationRequirement (string|int|array|null $value, int $position)
 ```
 
- 
+Set Pre CertificationRequirement (OBR.20) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 20  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1140,20 +1392,25 @@ public setPreCertificationRequirement (void)
 **Description**
 
 ```php
-public setSecondOpinionDate (void)
+public setSecondOpinionDate (string|int|array|null $value, int $position)
 ```
 
- 
+Set Second OpinionDate (OBR.22) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 22  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1163,20 +1420,25 @@ public setSecondOpinionDate (void)
 **Description**
 
 ```php
-public setSecondOpinionDocumentationReceived (void)
+public setSecondOpinionDocumentationReceived (string|int|array|null $value, int $position)
 ```
 
- 
+Set Second OpinionDocumentationReceived (OBR.24) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 24  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1186,20 +1448,25 @@ public setSecondOpinionDocumentationReceived (void)
 **Description**
 
 ```php
-public setSecondOpinionPhysician (void)
+public setSecondOpinionPhysician (string|int|array|null $value, int $position)
 ```
 
- 
+Set Second OpinionPhysician (OBR.25) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 25  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1209,20 +1476,25 @@ public setSecondOpinionPhysician (void)
 **Description**
 
 ```php
-public setSecondOpinionStatus (void)
+public setSecondOpinionStatus (string|int|array|null $value, int $position)
 ```
 
- 
+Set Second OpinionStatus (OBR.23) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 23  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 

--- a/docs/Segments/MSH.md
+++ b/docs/Segments/MSH.md
@@ -28,40 +28,41 @@ Aranyasen\HL7\Segment
 
 | Name | Description |
 |------|-------------|
-|[getDateTimeOfMessage](#mshgetdatetimeofmessage)||
-|[getMessageControlId](#mshgetmessagecontrolid)||
-|[getMessageType](#mshgetmessagetype)|ORM / ORU etc.|
-|[getProcessingId](#mshgetprocessingid)||
-|[getReceivingApplication](#mshgetreceivingapplication)||
-|[getReceivingFacility](#mshgetreceivingfacility)||
-|[getSendingApplication](#mshgetsendingapplication)||
-|[getSendingFacility](#mshgetsendingfacility)||
-|[getTriggerEvent](#mshgettriggerevent)||
-|[getVersionId](#mshgetversionid)|Get HL7 version, e.g. 2.1, 2.3, 3.0 etc.|
-|[setAcceptAcknowledgementType](#mshsetacceptacknowledgementtype)||
-|[setApplicationAcknowledgementType](#mshsetapplicationacknowledgementtype)||
-|[setCharacterSet](#mshsetcharacterset)||
-|[setContinuationPointer](#mshsetcontinuationpointer)||
-|[setCountryCode](#mshsetcountrycode)||
-|[setDateTimeOfMessage](#mshsetdatetimeofmessage)||
-|[setMessageControlId](#mshsetmessagecontrolid)||
-|[setMessageType](#mshsetmessagetype)|Sets message type to MSH segment.|
-|[setPrincipalLanguage](#mshsetprincipallanguage)||
-|[setProcessingId](#mshsetprocessingid)||
-|[setReceivingApplication](#mshsetreceivingapplication)||
-|[setReceivingFacility](#mshsetreceivingfacility)||
-|[setSecurity](#mshsetsecurity)||
-|[setSendingApplication](#mshsetsendingapplication)||
-|[setSendingFacility](#mshsetsendingfacility)||
-|[setSequenceNumber](#mshsetsequencenumber)||
-|[setTriggerEvent](#mshsettriggerevent)|Sets trigger event to MSH segment.|
-|[setVersionId](#mshsetversionid)||
+|[getDateTimeOfMessage](#mshgetdatetimeofmessage)|Get Date TimeOfMessage (OBR.7)|
+|[getMessageControlId](#mshgetmessagecontrolid)|Get Message ControlId (OBR.10)|
+|[getMessageType](#mshgetmessagetype)|Get Message Type (OBR.9)|
+|[getProcessingId](#mshgetprocessingid)|Get Processing Id (OBR.11)|
+|[getReceivingApplication](#mshgetreceivingapplication)|Get Receiving Application (OBR.5)|
+|[getReceivingFacility](#mshgetreceivingfacility)|Get Receiving Facility (OBR.6)|
+|[getSendingApplication](#mshgetsendingapplication)|Get Sending Application (OBR.3)|
+|[getSendingFacility](#mshgetsendingfacility)|Get Sending Facility (OBR.4)|
+|[getTriggerEvent](#mshgettriggerevent)|Get Trigger Event (OBR.9)|
+|[getVersionId](#mshgetversionid)|Get Version Id (OBR.12)|
+|[setAcceptAcknowledgementType](#mshsetacceptacknowledgementtype)|Set Accept AcknowledgementType (OBR.15)|
+|[setApplicationAcknowledgementType](#mshsetapplicationacknowledgementtype)|Set Application AcknowledgementType (OBR.16)|
+|[setCharacterSet](#mshsetcharacterset)|Set Character Set (OBR.18)|
+|[setContinuationPointer](#mshsetcontinuationpointer)|Set Continuation Pointer (OBR.14)|
+|[setCountryCode](#mshsetcountrycode)|Set Country Code (OBR.17)|
+|[setDateTimeOfMessage](#mshsetdatetimeofmessage)|Set Date TimeOfMessage (OBR.7)|
+|[setMessageControlId](#mshsetmessagecontrolid)|Set Message ControlId (OBR.10)|
+|[setMessageType](#mshsetmessagetype)|Sets message type to MSH segment. (OBR.9)|
+|[setPrincipalLanguage](#mshsetprincipallanguage)|Set Principal Language (OBR.19)|
+|[setProcessingId](#mshsetprocessingid)|Set Processing Id (OBR.11)|
+|[setReceivingApplication](#mshsetreceivingapplication)|Set Receiving Application (OBR.5)|
+|[setReceivingFacility](#mshsetreceivingfacility)|Set Receiving Facility (OBR.6)|
+|[setSecurity](#mshsetsecurity)|Set Security (OBR.8)|
+|[setSendingApplication](#mshsetsendingapplication)|Set Sending Application (OBR.3)|
+|[setSendingFacility](#mshsetsendingfacility)|Set Sending Facility (OBR.4)|
+|[setSequenceNumber](#mshsetsequencenumber)|Set Sequence Number (OBR.13)|
+|[setTriggerEvent](#mshsettriggerevent)|Sets trigger event to MSH segment. (OBR.9)|
+|[setVersionId](#mshsetversionid)|Set Version Id (OBR.12)|
 
 ## Inherited methods
 
 | Name | Description |
 |------|-------------|
 |__construct|Create a segment.|
+|clearField|Remove any existing value from the field|
 |getField|Get the field at index.|
 |getFields|Get fields from a segment|
 |getName|Get the name of the segment. This is basically the value at index 0|
@@ -75,20 +76,24 @@ Aranyasen\HL7\Segment
 **Description**
 
 ```php
-public getDateTimeOfMessage (void)
+public getDateTimeOfMessage (int $position)
 ```
 
- 
+Get Date TimeOfMessage (OBR.7) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 7  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -98,20 +103,24 @@ public getDateTimeOfMessage (void)
 **Description**
 
 ```php
-public getMessageControlId (void)
+public getMessageControlId (int $position)
 ```
 
- 
+Get Message ControlId (OBR.10) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 10  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -124,17 +133,19 @@ public getMessageControlId (void)
 public getMessageType (int $position)
 ```
 
-ORM / ORU etc. 
+Get Message Type (OBR.9) 
 
  
 
 **Parameters**
 
 * `(int) $position`
+: Defaults to 9  
 
 **Return Values**
 
-`string`
+`array|string|int|null`
+
 
 
 
@@ -146,20 +157,24 @@ ORM / ORU etc.
 **Description**
 
 ```php
-public getProcessingId (void)
+public getProcessingId (int $position)
 ```
 
- 
+Get Processing Id (OBR.11) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 11  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -169,20 +184,24 @@ public getProcessingId (void)
 **Description**
 
 ```php
-public getReceivingApplication (void)
+public getReceivingApplication (int $position)
 ```
 
- 
+Get Receiving Application (OBR.5) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 5  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -192,20 +211,24 @@ public getReceivingApplication (void)
 **Description**
 
 ```php
-public getReceivingFacility (void)
+public getReceivingFacility (int $position)
 ```
 
- 
+Get Receiving Facility (OBR.6) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 6  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -215,20 +238,24 @@ public getReceivingFacility (void)
 **Description**
 
 ```php
-public getSendingApplication (void)
+public getSendingApplication (int $position)
 ```
 
- 
+Get Sending Application (OBR.3) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 3  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -238,20 +265,24 @@ public getSendingApplication (void)
 **Description**
 
 ```php
-public getSendingFacility (void)
+public getSendingFacility (int $position)
 ```
 
- 
+Get Sending Facility (OBR.4) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 4  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -261,20 +292,24 @@ public getSendingFacility (void)
 **Description**
 
 ```php
-public getTriggerEvent (void)
+public getTriggerEvent (int $position)
 ```
 
- 
+Get Trigger Event (OBR.9) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 9  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -287,17 +322,19 @@ public getTriggerEvent (void)
 public getVersionId (int $position)
 ```
 
-Get HL7 version, e.g. 2.1, 2.3, 3.0 etc. 
+Get Version Id (OBR.12) 
 
  
 
 **Parameters**
 
 * `(int) $position`
+: Defaults to 12  
 
 **Return Values**
 
-`array|null|string`
+`array|string|int|null`
+
 
 
 
@@ -309,20 +346,25 @@ Get HL7 version, e.g. 2.1, 2.3, 3.0 etc.
 **Description**
 
 ```php
-public setAcceptAcknowledgementType (void)
+public setAcceptAcknowledgementType (string|int|array|null $value, int $position)
 ```
 
- 
+Set Accept AcknowledgementType (OBR.15) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 15  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -332,20 +374,25 @@ public setAcceptAcknowledgementType (void)
 **Description**
 
 ```php
-public setApplicationAcknowledgementType (void)
+public setApplicationAcknowledgementType (string|int|array|null $value, int $position)
 ```
 
- 
+Set Application AcknowledgementType (OBR.16) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 16  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -355,20 +402,25 @@ public setApplicationAcknowledgementType (void)
 **Description**
 
 ```php
-public setCharacterSet (void)
+public setCharacterSet (string|int|array|null $value, int $position)
 ```
 
- 
+Set Character Set (OBR.18) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 18  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -378,20 +430,25 @@ public setCharacterSet (void)
 **Description**
 
 ```php
-public setContinuationPointer (void)
+public setContinuationPointer (string|int|array|null $value, int $position)
 ```
 
- 
+Set Continuation Pointer (OBR.14) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 14  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -401,20 +458,25 @@ public setContinuationPointer (void)
 **Description**
 
 ```php
-public setCountryCode (void)
+public setCountryCode (string|int|array|null $value, int $position)
 ```
 
- 
+Set Country Code (OBR.17) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 17  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -424,20 +486,25 @@ public setCountryCode (void)
 **Description**
 
 ```php
-public setDateTimeOfMessage (void)
+public setDateTimeOfMessage (string|int|array|null $value, int $position)
 ```
 
- 
+Set Date TimeOfMessage (OBR.7) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 7  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -447,20 +514,25 @@ public setDateTimeOfMessage (void)
 **Description**
 
 ```php
-public setMessageControlId (void)
+public setMessageControlId (string|int|array|null $value, int $position)
 ```
 
- 
+Set Message ControlId (OBR.10) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 10  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -470,10 +542,10 @@ public setMessageControlId (void)
 **Description**
 
 ```php
-public setMessageType (string $value, int $position)
+public setMessageType (string|int|array|null $value, int $position)
 ```
 
-Sets message type to MSH segment. 
+Sets message type to MSH segment. (OBR.9) 
 
 If trigger event is already set, then it is preserved  
   
@@ -490,12 +562,14 @@ If it was empty then the new value will be just ORM.
 
 **Parameters**
 
-* `(string) $value`
+* `(string|int|array|null) $value`
 * `(int) $position`
+: Defaults to 9  
 
 **Return Values**
 
 `bool`
+
 
 
 
@@ -507,20 +581,25 @@ If it was empty then the new value will be just ORM.
 **Description**
 
 ```php
-public setPrincipalLanguage (void)
+public setPrincipalLanguage (string|int|array|null $value, int $position)
 ```
 
- 
+Set Principal Language (OBR.19) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 19  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -530,20 +609,25 @@ public setPrincipalLanguage (void)
 **Description**
 
 ```php
-public setProcessingId (void)
+public setProcessingId (string|int|array|null $value, int $position)
 ```
 
- 
+Set Processing Id (OBR.11) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 11  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -553,20 +637,25 @@ public setProcessingId (void)
 **Description**
 
 ```php
-public setReceivingApplication (void)
+public setReceivingApplication (string|int|array|null $value, int $position)
 ```
 
- 
+Set Receiving Application (OBR.5) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 5  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -576,20 +665,25 @@ public setReceivingApplication (void)
 **Description**
 
 ```php
-public setReceivingFacility (void)
+public setReceivingFacility (string|int|array|null $value, int $position)
 ```
 
- 
+Set Receiving Facility (OBR.6) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 6  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -599,20 +693,25 @@ public setReceivingFacility (void)
 **Description**
 
 ```php
-public setSecurity (void)
+public setSecurity (string|int|array|null $value, int $position)
 ```
 
- 
+Set Security (OBR.8) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 8  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -622,20 +721,25 @@ public setSecurity (void)
 **Description**
 
 ```php
-public setSendingApplication (void)
+public setSendingApplication (string|int|array|null $value, int $position)
 ```
 
- 
+Set Sending Application (OBR.3) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 3  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -645,20 +749,25 @@ public setSendingApplication (void)
 **Description**
 
 ```php
-public setSendingFacility (void)
+public setSendingFacility (string|int|array|null $value, int $position)
 ```
 
- 
+Set Sending Facility (OBR.4) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 4  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -668,20 +777,25 @@ public setSendingFacility (void)
 **Description**
 
 ```php
-public setSequenceNumber (void)
+public setSequenceNumber (string|int|array|null $value, int $position)
 ```
 
- 
+Set Sequence Number (OBR.13) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 13  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -691,10 +805,10 @@ public setSequenceNumber (void)
 **Description**
 
 ```php
-public setTriggerEvent (string $value, int $position)
+public setTriggerEvent (string|int|array|null $value, int $position)
 ```
 
-Sets trigger event to MSH segment. 
+Sets trigger event to MSH segment. (OBR.9) 
 
 If meessage type is already set, then it is preserved  
   
@@ -711,12 +825,14 @@ If trigger event was not set then it will set the new value.
 
 **Parameters**
 
-* `(string) $value`
+* `(string|int|array|null) $value`
 * `(int) $position`
+: Defaults to 9  
 
 **Return Values**
 
 `bool`
+
 
 
 
@@ -728,20 +844,25 @@ If trigger event was not set then it will set the new value.
 **Description**
 
 ```php
-public setVersionId (void)
+public setVersionId (string|int|array|null $value, int $position)
 ```
 
- 
+Set Version Id (OBR.12) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 12  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 

--- a/docs/Segments/NTE.md
+++ b/docs/Segments/NTE.md
@@ -13,20 +13,23 @@ Aranyasen\HL7\Segment
 
 | Name | Description |
 |------|-------------|
-|[getComment](#ntegetcomment)||
-|[getCommentType](#ntegetcommenttype)||
-|[getID](#ntegetid)||
-|[getSourceOfComment](#ntegetsourceofcomment)||
-|[setComment](#ntesetcomment)||
-|[setCommentType](#ntesetcommenttype)||
+|[__destruct](#nte__destruct)||
+|[getComment](#ntegetcomment)|Get Comment (OBR.3)|
+|[getCommentType](#ntegetcommenttype)|Get Comment Type (OBR.4)|
+|[getID](#ntegetid)|Get ID (OBR.1)|
+|[getSourceOfComment](#ntegetsourceofcomment)|Get Source OfComment (OBR.2)|
+|[resetIndex](#nteresetindex)|Reset index of this segment|
+|[setComment](#ntesetcomment)|Set Comment (OBR.3)|
+|[setCommentType](#ntesetcommenttype)|Set Comment Type (OBR.4)|
 |[setID](#ntesetid)||
-|[setSourceOfComment](#ntesetsourceofcomment)||
+|[setSourceOfComment](#ntesetsourceofcomment)|Set Source OfComment (OBR.2)|
 
 ## Inherited methods
 
 | Name | Description |
 |------|-------------|
 |__construct|Create a segment.|
+|clearField|Remove any existing value from the field|
 |getField|Get the field at index.|
 |getFields|Get fields from a segment|
 |getName|Get the name of the segment. This is basically the value at index 0|
@@ -35,12 +38,12 @@ Aranyasen\HL7\Segment
 
 
 
-### NTE::getComment  
+### NTE::__destruct  
 
 **Description**
 
 ```php
-public getComment (void)
+ __destruct (void)
 ```
 
  
@@ -54,6 +57,34 @@ public getComment (void)
 **Return Values**
 
 `void`
+
+
+<hr />
+
+
+### NTE::getComment  
+
+**Description**
+
+```php
+public getComment (int $position)
+```
+
+Get Comment (OBR.3) 
+
+ 
+
+**Parameters**
+
+* `(int) $position`
+: Defaults to 3  
+
+**Return Values**
+
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -63,20 +94,24 @@ public getComment (void)
 **Description**
 
 ```php
-public getCommentType (void)
+public getCommentType (int $position)
 ```
 
- 
+Get Comment Type (OBR.4) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 4  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -86,20 +121,24 @@ public getCommentType (void)
 **Description**
 
 ```php
-public getID (void)
+public getID (int $position)
 ```
 
- 
+Get ID (OBR.1) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 1  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -109,10 +148,37 @@ public getID (void)
 **Description**
 
 ```php
-public getSourceOfComment (void)
+public getSourceOfComment (int $position)
 ```
 
+Get Source OfComment (OBR.2) 
+
  
+
+**Parameters**
+
+* `(int) $position`
+: Defaults to 2  
+
+**Return Values**
+
+`array|string|int|null`
+
+
+
+
+<hr />
+
+
+### NTE::resetIndex  
+
+**Description**
+
+```php
+public static resetIndex (void)
+```
+
+Reset index of this segment 
 
  
 
@@ -123,6 +189,7 @@ public getSourceOfComment (void)
 **Return Values**
 
 `void`
+
 
 <hr />
 
@@ -132,20 +199,25 @@ public getSourceOfComment (void)
 **Description**
 
 ```php
-public setComment (void)
+public setComment (string|int|array|null $value, int $position)
 ```
 
- 
+Set Comment (OBR.3) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 3  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -155,20 +227,25 @@ public setComment (void)
 **Description**
 
 ```php
-public setCommentType (void)
+public setCommentType (string|int|array|null $value, int $position)
 ```
 
- 
+Set Comment Type (OBR.4) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 4  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -178,7 +255,7 @@ public setCommentType (void)
 **Description**
 
 ```php
-public setID (void)
+ setID (void)
 ```
 
  
@@ -192,6 +269,7 @@ public setID (void)
 **Return Values**
 
 `void`
+
 
 <hr />
 
@@ -201,20 +279,25 @@ public setID (void)
 **Description**
 
 ```php
-public setSourceOfComment (void)
+public setSourceOfComment (string|int|array|null $value, int $position)
 ```
 
- 
+Set Source OfComment (OBR.2) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 2  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 

--- a/docs/Segments/OBR.md
+++ b/docs/Segments/OBR.md
@@ -13,98 +13,101 @@ Aranyasen\HL7\Segment
 
 | Name | Description |
 |------|-------------|
-|[getAssistantResultInterpreter](#obrgetassistantresultinterpreter)||
-|[getChargetoPractice](#obrgetchargetopractice)||
-|[getCollectionVolume](#obrgetcollectionvolume)||
-|[getCollectorIdentifier](#obrgetcollectoridentifier)||
-|[getCollectorsComment](#obrgetcollectorscomment)||
-|[getDangerCode](#obrgetdangercode)||
-|[getDiagnosticServSectID](#obrgetdiagnosticservsectid)||
-|[getEscortRequired](#obrgetescortrequired)||
+|[__destruct](#obr__destruct)||
+|[getAssistantResultInterpreter](#obrgetassistantresultinterpreter)|Get Assistant ResultInterpreter (OBR.33)|
+|[getChargetoPractice](#obrgetchargetopractice)|Get Chargeto Practice (OBR.23)|
+|[getCollectionVolume](#obrgetcollectionvolume)|Get Collection Volume (OBR.9)|
+|[getCollectorIdentifier](#obrgetcollectoridentifier)|Get Collector Identifier (OBR.10)|
+|[getCollectorsComment](#obrgetcollectorscomment)|Get Collectors Comment (OBR.39)|
+|[getDangerCode](#obrgetdangercode)|Get Danger Code (OBR.12)|
+|[getDiagnosticServSectID](#obrgetdiagnosticservsectid)|Get Diagnostic ServSectID (OBR.24)|
+|[getEscortRequired](#obrgetescortrequired)|Get Escort Required (OBR.42)|
 |[getFillerField1](#obrgetfillerfield1)||
 |[getFillerField2](#obrgetfillerfield2)||
-|[getFillerOrderNumber](#obrgetfillerordernumber)||
-|[getID](#obrgetid)||
-|[getNumberofSampleContainers](#obrgetnumberofsamplecontainers)||
-|[getObservationDateTime](#obrgetobservationdatetime)||
-|[getObservationEndDateTime](#obrgetobservationenddatetime)||
-|[getOrderCallbackPhoneNumber](#obrgetordercallbackphonenumber)||
-|[getOrderingProvider](#obrgetorderingprovider)||
-|[getParent](#obrgetparent)||
-|[getParentResult](#obrgetparentresult)||
-|[getPlacerOrderNumber](#obrgetplacerordernumber)||
+|[getFillerOrderNumber](#obrgetfillerordernumber)|Get Filler OrderNumber (OBR.3)|
+|[getID](#obrgetid)|Get ID (OBR.1)|
+|[getNumberofSampleContainers](#obrgetnumberofsamplecontainers)|Get Numberof SampleContainers (OBR.37)|
+|[getObservationDateTime](#obrgetobservationdatetime)|Get Observation DateTime (OBR.7)|
+|[getObservationEndDateTime](#obrgetobservationenddatetime)|Get Observation EndDateTime (OBR.8)|
+|[getOrderCallbackPhoneNumber](#obrgetordercallbackphonenumber)|Get Order CallbackPhoneNumber (OBR.17)|
+|[getOrderingProvider](#obrgetorderingprovider)|Get Ordering Provider (OBR.16)|
+|[getParent](#obrgetparent)|Get Parent (OBR.29)|
+|[getParentResult](#obrgetparentresult)|Get Parent Result (OBR.26)|
+|[getPlacerOrderNumber](#obrgetplacerordernumber)|Get Placer OrderNumber (OBR.2)|
 |[getPlacerfield1](#obrgetplacerfield1)||
 |[getPlacerfield2](#obrgetplacerfield2)||
-|[getPlannedPatientTransportComment](#obrgetplannedpatienttransportcomment)||
-|[getPrincipalResultInterpreter](#obrgetprincipalresultinterpreter)||
-|[getPriority](#obrgetpriority)||
-|[getQuantityTiming](#obrgetquantitytiming)||
-|[getReasonforStudy](#obrgetreasonforstudy)||
-|[getRelevantClinicalInfo](#obrgetrelevantclinicalinfo)||
-|[getRequestedDatetime](#obrgetrequesteddatetime)||
-|[getResultCopiesTo](#obrgetresultcopiesto)||
-|[getResultStatus](#obrgetresultstatus)||
-|[getResultsRptStatusChngDateTime](#obrgetresultsrptstatuschngdatetime)||
-|[getScheduledDateTime](#obrgetscheduleddatetime)||
-|[getSpecimenActionCode](#obrgetspecimenactioncode)||
-|[getSpecimenReceivedDateTime](#obrgetspecimenreceiveddatetime)||
-|[getSpecimenSource](#obrgetspecimensource)||
-|[getTechnician](#obrgettechnician)||
-|[getTranscriptionist](#obrgettranscriptionist)||
-|[getTransportArranged](#obrgettransportarranged)||
-|[getTransportArrangementResponsibility](#obrgettransportarrangementresponsibility)||
-|[getTransportLogisticsofCollectedSample](#obrgettransportlogisticsofcollectedsample)||
-|[getTransportationMode](#obrgettransportationmode)||
-|[getUniversalServiceID](#obrgetuniversalserviceid)||
-|[setAssistantResultInterpreter](#obrsetassistantresultinterpreter)||
-|[setChargetoPractice](#obrsetchargetopractice)||
-|[setCollectionVolume](#obrsetcollectionvolume)||
-|[setCollectorIdentifier](#obrsetcollectoridentifier)||
-|[setCollectorsComment](#obrsetcollectorscomment)||
-|[setDangerCode](#obrsetdangercode)||
-|[setDiagnosticServSectID](#obrsetdiagnosticservsectid)||
-|[setEscortRequired](#obrsetescortrequired)||
+|[getPlannedPatientTransportComment](#obrgetplannedpatienttransportcomment)|Get Planned PatientTransportComment (OBR.43)|
+|[getPrincipalResultInterpreter](#obrgetprincipalresultinterpreter)|Get Principal ResultInterpreter (OBR.32)|
+|[getPriority](#obrgetpriority)|Get Priority (OBR.5)|
+|[getQuantityTiming](#obrgetquantitytiming)|Get Quantity Timing (OBR.27)|
+|[getReasonforStudy](#obrgetreasonforstudy)|Get Reasonfor Study (OBR.31)|
+|[getRelevantClinicalInfo](#obrgetrelevantclinicalinfo)|Get Relevant ClinicalInfo (OBR.13)|
+|[getRequestedDatetime](#obrgetrequesteddatetime)|Get Requested Datetime (OBR.6)|
+|[getResultCopiesTo](#obrgetresultcopiesto)|Get Result CopiesTo (OBR.28)|
+|[getResultStatus](#obrgetresultstatus)|Get Result Status (OBR.25)|
+|[getResultsRptStatusChngDateTime](#obrgetresultsrptstatuschngdatetime)|Get Results RptStatusChngDateTime (OBR.22)|
+|[getScheduledDateTime](#obrgetscheduleddatetime)|Get Scheduled DateTime (OBR.36)|
+|[getSpecimenActionCode](#obrgetspecimenactioncode)|Get Specimen ActionCode (OBR.11)|
+|[getSpecimenReceivedDateTime](#obrgetspecimenreceiveddatetime)|Get Specimen ReceivedDateTime (OBR.14)|
+|[getSpecimenSource](#obrgetspecimensource)|Get Specimen Source (OBR.15)|
+|[getTechnician](#obrgettechnician)|Get Technician (OBR.34)|
+|[getTranscriptionist](#obrgettranscriptionist)|Get Transcriptionist (OBR.35)|
+|[getTransportArranged](#obrgettransportarranged)|Get Transport Arranged (OBR.41)|
+|[getTransportArrangementResponsibility](#obrgettransportarrangementresponsibility)|Get Transport ArrangementResponsibility (OBR.40)|
+|[getTransportLogisticsofCollectedSample](#obrgettransportlogisticsofcollectedsample)|Get Transport LogisticsofCollectedSample (OBR.38)|
+|[getTransportationMode](#obrgettransportationmode)|Get Transportation Mode (OBR.30)|
+|[getUniversalServiceID](#obrgetuniversalserviceid)|Get Universal ServiceID (OBR.4)|
+|[resetIndex](#obrresetindex)|Reset index of this segment|
+|[setAssistantResultInterpreter](#obrsetassistantresultinterpreter)|Set Assistant ResultInterpreter (OBR.33)|
+|[setChargetoPractice](#obrsetchargetopractice)|Set Chargeto Practice (OBR.23)|
+|[setCollectionVolume](#obrsetcollectionvolume)|Set Collection Volume (OBR.9)|
+|[setCollectorIdentifier](#obrsetcollectoridentifier)|Set Collector Identifier (OBR.10)|
+|[setCollectorsComment](#obrsetcollectorscomment)|Set Collectors Comment (OBR.39)|
+|[setDangerCode](#obrsetdangercode)|Set Danger Code (OBR.12)|
+|[setDiagnosticServSectID](#obrsetdiagnosticservsectid)|Set Diagnostic ServSectID (OBR.24)|
+|[setEscortRequired](#obrsetescortrequired)|Set Escort Required (OBR.42)|
 |[setFillerField1](#obrsetfillerfield1)||
 |[setFillerField2](#obrsetfillerfield2)||
-|[setFillerOrderNumber](#obrsetfillerordernumber)||
+|[setFillerOrderNumber](#obrsetfillerordernumber)|Set Filler OrderNumber (OBR.3)|
 |[setID](#obrsetid)||
-|[setNumberofSampleContainers](#obrsetnumberofsamplecontainers)||
-|[setObservationDateTime](#obrsetobservationdatetime)||
-|[setObservationEndDateTime](#obrsetobservationenddatetime)||
-|[setOrderCallbackPhoneNumber](#obrsetordercallbackphonenumber)||
-|[setOrderingProvider](#obrsetorderingprovider)||
-|[setParent](#obrsetparent)||
-|[setParentResult](#obrsetparentresult)||
-|[setPlacerOrderNumber](#obrsetplacerordernumber)||
+|[setNumberofSampleContainers](#obrsetnumberofsamplecontainers)|Set Numberof SampleContainers (OBR.37)|
+|[setObservationDateTime](#obrsetobservationdatetime)|Set Observation DateTime (OBR.7)|
+|[setObservationEndDateTime](#obrsetobservationenddatetime)|Set Observation EndDateTime (OBR.8)|
+|[setOrderCallbackPhoneNumber](#obrsetordercallbackphonenumber)|Set Order CallbackPhoneNumber (OBR.17)|
+|[setOrderingProvider](#obrsetorderingprovider)|Set Ordering Provider (OBR.16)|
+|[setParent](#obrsetparent)|Set Parent (OBR.29)|
+|[setParentResult](#obrsetparentresult)|Set Parent Result (OBR.26)|
+|[setPlacerOrderNumber](#obrsetplacerordernumber)|Set Placer OrderNumber (OBR.2)|
 |[setPlacerfield1](#obrsetplacerfield1)||
 |[setPlacerfield2](#obrsetplacerfield2)||
-|[setPlannedPatientTransportComment](#obrsetplannedpatienttransportcomment)||
-|[setPrincipalResultInterpreter](#obrsetprincipalresultinterpreter)||
-|[setPriority](#obrsetpriority)||
-|[setQuantityTiming](#obrsetquantitytiming)||
-|[setReasonforStudy](#obrsetreasonforstudy)||
-|[setRelevantClinicalInfo](#obrsetrelevantclinicalinfo)||
-|[setRequestedDatetime](#obrsetrequesteddatetime)||
-|[setResultCopiesTo](#obrsetresultcopiesto)||
-|[setResultStatus](#obrsetresultstatus)||
-|[setResultsRptStatusChngDateTime](#obrsetresultsrptstatuschngdatetime)||
-|[setScheduledDateTime](#obrsetscheduleddatetime)||
-|[setSpecimenActionCode](#obrsetspecimenactioncode)||
-|[setSpecimenReceivedDateTime](#obrsetspecimenreceiveddatetime)||
-|[setSpecimenSource](#obrsetspecimensource)||
-|[setTechnician](#obrsettechnician)||
-|[setTranscriptionist](#obrsettranscriptionist)||
-|[setTransportArranged](#obrsettransportarranged)||
-|[setTransportArrangementResponsibility](#obrsettransportarrangementresponsibility)||
-|[setTransportLogisticsofCollectedSample](#obrsettransportlogisticsofcollectedsample)||
-|[setTransportationMode](#obrsettransportationmode)||
-|[setUniversalServiceID](#obrsetuniversalserviceid)||
+|[setPlannedPatientTransportComment](#obrsetplannedpatienttransportcomment)|Set Planned PatientTransportComment (OBR.43)|
+|[setPrincipalResultInterpreter](#obrsetprincipalresultinterpreter)|Set Principal ResultInterpreter (OBR.32)|
+|[setPriority](#obrsetpriority)|Set Priority (OBR.5)|
+|[setQuantityTiming](#obrsetquantitytiming)|Set Quantity Timing (OBR.27)|
+|[setReasonforStudy](#obrsetreasonforstudy)|Set Reasonfor Study (OBR.31)|
+|[setRelevantClinicalInfo](#obrsetrelevantclinicalinfo)|Set Relevant ClinicalInfo (OBR.13)|
+|[setRequestedDatetime](#obrsetrequesteddatetime)|Set Requested Datetime (OBR.6)|
+|[setResultCopiesTo](#obrsetresultcopiesto)|Set Result CopiesTo (OBR.28)|
+|[setResultStatus](#obrsetresultstatus)|Set Result Status (OBR.25)|
+|[setResultsRptStatusChngDateTime](#obrsetresultsrptstatuschngdatetime)|Set Results RptStatusChngDateTime (OBR.22)|
+|[setScheduledDateTime](#obrsetscheduleddatetime)|Set Scheduled DateTime (OBR.36)|
+|[setSpecimenActionCode](#obrsetspecimenactioncode)|Set Specimen ActionCode (OBR.11)|
+|[setSpecimenReceivedDateTime](#obrsetspecimenreceiveddatetime)|Set Specimen ReceivedDateTime (OBR.14)|
+|[setSpecimenSource](#obrsetspecimensource)|Set Specimen Source (OBR.15)|
+|[setTechnician](#obrsettechnician)|Set Technician (OBR.34)|
+|[setTranscriptionist](#obrsettranscriptionist)|Set Transcriptionist (OBR.35)|
+|[setTransportArranged](#obrsettransportarranged)|Set Transport Arranged (OBR.41)|
+|[setTransportArrangementResponsibility](#obrsettransportarrangementresponsibility)|Set Transport ArrangementResponsibility (OBR.40)|
+|[setTransportLogisticsofCollectedSample](#obrsettransportlogisticsofcollectedsample)|Set Transport LogisticsofCollectedSample (OBR.38)|
+|[setTransportationMode](#obrsettransportationmode)|Set Transportation Mode (OBR.30)|
+|[setUniversalServiceID](#obrsetuniversalserviceid)|Set Universal ServiceID (OBR.4)|
 
 ## Inherited methods
 
 | Name | Description |
 |------|-------------|
 |__construct|Create a segment.|
+|clearField|Remove any existing value from the field|
 |getField|Get the field at index.|
 |getFields|Get fields from a segment|
 |getName|Get the name of the segment. This is basically the value at index 0|
@@ -113,12 +116,12 @@ Aranyasen\HL7\Segment
 
 
 
-### OBR::getAssistantResultInterpreter  
+### OBR::__destruct  
 
 **Description**
 
 ```php
-public getAssistantResultInterpreter (void)
+ __destruct (void)
 ```
 
  
@@ -132,6 +135,34 @@ public getAssistantResultInterpreter (void)
 **Return Values**
 
 `void`
+
+
+<hr />
+
+
+### OBR::getAssistantResultInterpreter  
+
+**Description**
+
+```php
+public getAssistantResultInterpreter (int $position)
+```
+
+Get Assistant ResultInterpreter (OBR.33) 
+
+ 
+
+**Parameters**
+
+* `(int) $position`
+: Defaults to 33  
+
+**Return Values**
+
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -141,20 +172,24 @@ public getAssistantResultInterpreter (void)
 **Description**
 
 ```php
-public getChargetoPractice (void)
+public getChargetoPractice (int $position)
 ```
 
- 
+Get Chargeto Practice (OBR.23) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 23  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -164,20 +199,24 @@ public getChargetoPractice (void)
 **Description**
 
 ```php
-public getCollectionVolume (void)
+public getCollectionVolume (int $position)
 ```
 
- 
+Get Collection Volume (OBR.9) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 9  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -187,20 +226,24 @@ public getCollectionVolume (void)
 **Description**
 
 ```php
-public getCollectorIdentifier (void)
+public getCollectorIdentifier (int $position)
 ```
 
- 
+Get Collector Identifier (OBR.10) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 10  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -210,20 +253,24 @@ public getCollectorIdentifier (void)
 **Description**
 
 ```php
-public getCollectorsComment (void)
+public getCollectorsComment (int $position)
 ```
 
- 
+Get Collectors Comment (OBR.39) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 39  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -233,20 +280,24 @@ public getCollectorsComment (void)
 **Description**
 
 ```php
-public getDangerCode (void)
+public getDangerCode (int $position)
 ```
 
- 
+Get Danger Code (OBR.12) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 12  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -256,20 +307,24 @@ public getDangerCode (void)
 **Description**
 
 ```php
-public getDiagnosticServSectID (void)
+public getDiagnosticServSectID (int $position)
 ```
 
- 
+Get Diagnostic ServSectID (OBR.24) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 24  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -279,20 +334,24 @@ public getDiagnosticServSectID (void)
 **Description**
 
 ```php
-public getEscortRequired (void)
+public getEscortRequired (int $position)
 ```
 
- 
+Get Escort Required (OBR.42) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 42  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -302,7 +361,7 @@ public getEscortRequired (void)
 **Description**
 
 ```php
-public getFillerField1 (void)
+ getFillerField1 (void)
 ```
 
  
@@ -316,6 +375,7 @@ public getFillerField1 (void)
 **Return Values**
 
 `void`
+
 
 <hr />
 
@@ -325,7 +385,7 @@ public getFillerField1 (void)
 **Description**
 
 ```php
-public getFillerField2 (void)
+ getFillerField2 (void)
 ```
 
  
@@ -339,6 +399,7 @@ public getFillerField2 (void)
 **Return Values**
 
 `void`
+
 
 <hr />
 
@@ -348,20 +409,24 @@ public getFillerField2 (void)
 **Description**
 
 ```php
-public getFillerOrderNumber (void)
+public getFillerOrderNumber (int $position)
 ```
 
- 
+Get Filler OrderNumber (OBR.3) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 3  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -371,20 +436,24 @@ public getFillerOrderNumber (void)
 **Description**
 
 ```php
-public getID (void)
+public getID (int $position)
 ```
 
- 
+Get ID (OBR.1) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 1  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -394,20 +463,24 @@ public getID (void)
 **Description**
 
 ```php
-public getNumberofSampleContainers (void)
+public getNumberofSampleContainers (int $position)
 ```
 
- 
+Get Numberof SampleContainers (OBR.37) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 37  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -417,20 +490,24 @@ public getNumberofSampleContainers (void)
 **Description**
 
 ```php
-public getObservationDateTime (void)
+public getObservationDateTime (int $position)
 ```
 
- 
+Get Observation DateTime (OBR.7) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 7  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -440,20 +517,24 @@ public getObservationDateTime (void)
 **Description**
 
 ```php
-public getObservationEndDateTime (void)
+public getObservationEndDateTime (int $position)
 ```
 
- 
+Get Observation EndDateTime (OBR.8) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 8  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -463,20 +544,24 @@ public getObservationEndDateTime (void)
 **Description**
 
 ```php
-public getOrderCallbackPhoneNumber (void)
+public getOrderCallbackPhoneNumber (int $position)
 ```
 
- 
+Get Order CallbackPhoneNumber (OBR.17) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 17  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -486,20 +571,24 @@ public getOrderCallbackPhoneNumber (void)
 **Description**
 
 ```php
-public getOrderingProvider (void)
+public getOrderingProvider (int $position)
 ```
 
- 
+Get Ordering Provider (OBR.16) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 16  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -509,20 +598,24 @@ public getOrderingProvider (void)
 **Description**
 
 ```php
-public getParent (void)
+public getParent (int $position)
 ```
 
- 
+Get Parent (OBR.29) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 29  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -532,20 +625,24 @@ public getParent (void)
 **Description**
 
 ```php
-public getParentResult (void)
+public getParentResult (int $position)
 ```
 
- 
+Get Parent Result (OBR.26) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 26  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -555,20 +652,24 @@ public getParentResult (void)
 **Description**
 
 ```php
-public getPlacerOrderNumber (void)
+public getPlacerOrderNumber (int $position)
 ```
 
- 
+Get Placer OrderNumber (OBR.2) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 2  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -578,7 +679,7 @@ public getPlacerOrderNumber (void)
 **Description**
 
 ```php
-public getPlacerfield1 (void)
+ getPlacerfield1 (void)
 ```
 
  
@@ -592,6 +693,7 @@ public getPlacerfield1 (void)
 **Return Values**
 
 `void`
+
 
 <hr />
 
@@ -601,7 +703,7 @@ public getPlacerfield1 (void)
 **Description**
 
 ```php
-public getPlacerfield2 (void)
+ getPlacerfield2 (void)
 ```
 
  
@@ -615,6 +717,7 @@ public getPlacerfield2 (void)
 **Return Values**
 
 `void`
+
 
 <hr />
 
@@ -624,20 +727,24 @@ public getPlacerfield2 (void)
 **Description**
 
 ```php
-public getPlannedPatientTransportComment (void)
+public getPlannedPatientTransportComment (int $position)
 ```
 
- 
+Get Planned PatientTransportComment (OBR.43) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 43  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -647,20 +754,24 @@ public getPlannedPatientTransportComment (void)
 **Description**
 
 ```php
-public getPrincipalResultInterpreter (void)
+public getPrincipalResultInterpreter (int $position)
 ```
 
- 
+Get Principal ResultInterpreter (OBR.32) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 32  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -670,20 +781,24 @@ public getPrincipalResultInterpreter (void)
 **Description**
 
 ```php
-public getPriority (void)
+public getPriority (int $position)
 ```
 
- 
+Get Priority (OBR.5) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 5  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -693,20 +808,24 @@ public getPriority (void)
 **Description**
 
 ```php
-public getQuantityTiming (void)
+public getQuantityTiming (int $position)
 ```
 
- 
+Get Quantity Timing (OBR.27) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 27  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -716,20 +835,24 @@ public getQuantityTiming (void)
 **Description**
 
 ```php
-public getReasonforStudy (void)
+public getReasonforStudy (int $position)
 ```
 
- 
+Get Reasonfor Study (OBR.31) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 31  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -739,20 +862,24 @@ public getReasonforStudy (void)
 **Description**
 
 ```php
-public getRelevantClinicalInfo (void)
+public getRelevantClinicalInfo (int $position)
 ```
 
- 
+Get Relevant ClinicalInfo (OBR.13) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 13  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -762,20 +889,24 @@ public getRelevantClinicalInfo (void)
 **Description**
 
 ```php
-public getRequestedDatetime (void)
+public getRequestedDatetime (int $position)
 ```
 
- 
+Get Requested Datetime (OBR.6) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 6  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -785,20 +916,24 @@ public getRequestedDatetime (void)
 **Description**
 
 ```php
-public getResultCopiesTo (void)
+public getResultCopiesTo (int $position)
 ```
 
- 
+Get Result CopiesTo (OBR.28) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 28  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -808,20 +943,24 @@ public getResultCopiesTo (void)
 **Description**
 
 ```php
-public getResultStatus (void)
+public getResultStatus (int $position)
 ```
 
- 
+Get Result Status (OBR.25) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 25  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -831,20 +970,24 @@ public getResultStatus (void)
 **Description**
 
 ```php
-public getResultsRptStatusChngDateTime (void)
+public getResultsRptStatusChngDateTime (int $position)
 ```
 
- 
+Get Results RptStatusChngDateTime (OBR.22) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 22  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -854,20 +997,24 @@ public getResultsRptStatusChngDateTime (void)
 **Description**
 
 ```php
-public getScheduledDateTime (void)
+public getScheduledDateTime (int $position)
 ```
 
- 
+Get Scheduled DateTime (OBR.36) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 36  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -877,20 +1024,24 @@ public getScheduledDateTime (void)
 **Description**
 
 ```php
-public getSpecimenActionCode (void)
+public getSpecimenActionCode (int $position)
 ```
 
- 
+Get Specimen ActionCode (OBR.11) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 11  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -900,20 +1051,24 @@ public getSpecimenActionCode (void)
 **Description**
 
 ```php
-public getSpecimenReceivedDateTime (void)
+public getSpecimenReceivedDateTime (int $position)
 ```
 
- 
+Get Specimen ReceivedDateTime (OBR.14) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 14  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -923,20 +1078,24 @@ public getSpecimenReceivedDateTime (void)
 **Description**
 
 ```php
-public getSpecimenSource (void)
+public getSpecimenSource (int $position)
 ```
 
- 
+Get Specimen Source (OBR.15) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 15  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -946,20 +1105,24 @@ public getSpecimenSource (void)
 **Description**
 
 ```php
-public getTechnician (void)
+public getTechnician (int $position)
 ```
 
- 
+Get Technician (OBR.34) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 34  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -969,20 +1132,24 @@ public getTechnician (void)
 **Description**
 
 ```php
-public getTranscriptionist (void)
+public getTranscriptionist (int $position)
 ```
 
- 
+Get Transcriptionist (OBR.35) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 35  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -992,20 +1159,24 @@ public getTranscriptionist (void)
 **Description**
 
 ```php
-public getTransportArranged (void)
+public getTransportArranged (int $position)
 ```
 
- 
+Get Transport Arranged (OBR.41) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 41  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -1015,20 +1186,24 @@ public getTransportArranged (void)
 **Description**
 
 ```php
-public getTransportArrangementResponsibility (void)
+public getTransportArrangementResponsibility (int $position)
 ```
 
- 
+Get Transport ArrangementResponsibility (OBR.40) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 40  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -1038,20 +1213,24 @@ public getTransportArrangementResponsibility (void)
 **Description**
 
 ```php
-public getTransportLogisticsofCollectedSample (void)
+public getTransportLogisticsofCollectedSample (int $position)
 ```
 
- 
+Get Transport LogisticsofCollectedSample (OBR.38) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 38  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -1061,20 +1240,24 @@ public getTransportLogisticsofCollectedSample (void)
 **Description**
 
 ```php
-public getTransportationMode (void)
+public getTransportationMode (int $position)
 ```
 
- 
+Get Transportation Mode (OBR.30) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 30  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -1084,10 +1267,37 @@ public getTransportationMode (void)
 **Description**
 
 ```php
-public getUniversalServiceID (void)
+public getUniversalServiceID (int $position)
 ```
 
+Get Universal ServiceID (OBR.4) 
+
  
+
+**Parameters**
+
+* `(int) $position`
+: Defaults to 4  
+
+**Return Values**
+
+`array|string|int|null`
+
+
+
+
+<hr />
+
+
+### OBR::resetIndex  
+
+**Description**
+
+```php
+public static resetIndex (void)
+```
+
+Reset index of this segment 
 
  
 
@@ -1098,6 +1308,7 @@ public getUniversalServiceID (void)
 **Return Values**
 
 `void`
+
 
 <hr />
 
@@ -1107,20 +1318,25 @@ public getUniversalServiceID (void)
 **Description**
 
 ```php
-public setAssistantResultInterpreter (void)
+public setAssistantResultInterpreter (string|int|array|null $value, int $position)
 ```
 
- 
+Set Assistant ResultInterpreter (OBR.33) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 33  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1130,20 +1346,25 @@ public setAssistantResultInterpreter (void)
 **Description**
 
 ```php
-public setChargetoPractice (void)
+public setChargetoPractice (string|int|array|null $value, int $position)
 ```
 
- 
+Set Chargeto Practice (OBR.23) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 23  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1153,20 +1374,25 @@ public setChargetoPractice (void)
 **Description**
 
 ```php
-public setCollectionVolume (void)
+public setCollectionVolume (string|int|array|null $value, int $position)
 ```
 
- 
+Set Collection Volume (OBR.9) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 9  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1176,20 +1402,25 @@ public setCollectionVolume (void)
 **Description**
 
 ```php
-public setCollectorIdentifier (void)
+public setCollectorIdentifier (string|int|array|null $value, int $position)
 ```
 
- 
+Set Collector Identifier (OBR.10) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 10  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1199,20 +1430,25 @@ public setCollectorIdentifier (void)
 **Description**
 
 ```php
-public setCollectorsComment (void)
+public setCollectorsComment (string|int|array|null $value, int $position)
 ```
 
- 
+Set Collectors Comment (OBR.39) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 39  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1222,20 +1458,25 @@ public setCollectorsComment (void)
 **Description**
 
 ```php
-public setDangerCode (void)
+public setDangerCode (string|int|array|null $value, int $position)
 ```
 
- 
+Set Danger Code (OBR.12) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 12  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1245,20 +1486,25 @@ public setDangerCode (void)
 **Description**
 
 ```php
-public setDiagnosticServSectID (void)
+public setDiagnosticServSectID (string|int|array|null $value, int $position)
 ```
 
- 
+Set Diagnostic ServSectID (OBR.24) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 24  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1268,20 +1514,25 @@ public setDiagnosticServSectID (void)
 **Description**
 
 ```php
-public setEscortRequired (void)
+public setEscortRequired (string|int|array|null $value, int $position)
 ```
 
- 
+Set Escort Required (OBR.42) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 42  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1291,7 +1542,7 @@ public setEscortRequired (void)
 **Description**
 
 ```php
-public setFillerField1 (void)
+ setFillerField1 (void)
 ```
 
  
@@ -1305,6 +1556,7 @@ public setFillerField1 (void)
 **Return Values**
 
 `void`
+
 
 <hr />
 
@@ -1314,7 +1566,7 @@ public setFillerField1 (void)
 **Description**
 
 ```php
-public setFillerField2 (void)
+ setFillerField2 (void)
 ```
 
  
@@ -1328,6 +1580,7 @@ public setFillerField2 (void)
 **Return Values**
 
 `void`
+
 
 <hr />
 
@@ -1337,20 +1590,25 @@ public setFillerField2 (void)
 **Description**
 
 ```php
-public setFillerOrderNumber (void)
+public setFillerOrderNumber (string|int|array|null $value, int $position)
 ```
 
- 
+Set Filler OrderNumber (OBR.3) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 3  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1360,7 +1618,7 @@ public setFillerOrderNumber (void)
 **Description**
 
 ```php
-public setID (void)
+ setID (void)
 ```
 
  
@@ -1374,6 +1632,7 @@ public setID (void)
 **Return Values**
 
 `void`
+
 
 <hr />
 
@@ -1383,20 +1642,25 @@ public setID (void)
 **Description**
 
 ```php
-public setNumberofSampleContainers (void)
+public setNumberofSampleContainers (string|int|array|null $value, int $position)
 ```
 
- 
+Set Numberof SampleContainers (OBR.37) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 37  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1406,20 +1670,25 @@ public setNumberofSampleContainers (void)
 **Description**
 
 ```php
-public setObservationDateTime (void)
+public setObservationDateTime (string|int|array|null $value, int $position)
 ```
 
- 
+Set Observation DateTime (OBR.7) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 7  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1429,20 +1698,25 @@ public setObservationDateTime (void)
 **Description**
 
 ```php
-public setObservationEndDateTime (void)
+public setObservationEndDateTime (string|int|array|null $value, int $position)
 ```
 
- 
+Set Observation EndDateTime (OBR.8) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 8  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1452,20 +1726,25 @@ public setObservationEndDateTime (void)
 **Description**
 
 ```php
-public setOrderCallbackPhoneNumber (void)
+public setOrderCallbackPhoneNumber (string|int|array|null $value, int $position)
 ```
 
- 
+Set Order CallbackPhoneNumber (OBR.17) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 17  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1475,20 +1754,25 @@ public setOrderCallbackPhoneNumber (void)
 **Description**
 
 ```php
-public setOrderingProvider (void)
+public setOrderingProvider (string|int|array|null $value, int $position)
 ```
 
- 
+Set Ordering Provider (OBR.16) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 16  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1498,20 +1782,25 @@ public setOrderingProvider (void)
 **Description**
 
 ```php
-public setParent (void)
+public setParent (string|int|array|null $value, int $position)
 ```
 
- 
+Set Parent (OBR.29) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 29  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1521,20 +1810,25 @@ public setParent (void)
 **Description**
 
 ```php
-public setParentResult (void)
+public setParentResult (string|int|array|null $value, int $position)
 ```
 
- 
+Set Parent Result (OBR.26) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 26  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1544,20 +1838,25 @@ public setParentResult (void)
 **Description**
 
 ```php
-public setPlacerOrderNumber (void)
+public setPlacerOrderNumber (string|int|array|null $value, int $position)
 ```
 
- 
+Set Placer OrderNumber (OBR.2) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 2  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1567,7 +1866,7 @@ public setPlacerOrderNumber (void)
 **Description**
 
 ```php
-public setPlacerfield1 (void)
+ setPlacerfield1 (void)
 ```
 
  
@@ -1581,6 +1880,7 @@ public setPlacerfield1 (void)
 **Return Values**
 
 `void`
+
 
 <hr />
 
@@ -1590,7 +1890,7 @@ public setPlacerfield1 (void)
 **Description**
 
 ```php
-public setPlacerfield2 (void)
+ setPlacerfield2 (void)
 ```
 
  
@@ -1604,6 +1904,7 @@ public setPlacerfield2 (void)
 **Return Values**
 
 `void`
+
 
 <hr />
 
@@ -1613,20 +1914,25 @@ public setPlacerfield2 (void)
 **Description**
 
 ```php
-public setPlannedPatientTransportComment (void)
+public setPlannedPatientTransportComment (string|int|array|null $value, int $position)
 ```
 
- 
+Set Planned PatientTransportComment (OBR.43) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 43  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1636,20 +1942,25 @@ public setPlannedPatientTransportComment (void)
 **Description**
 
 ```php
-public setPrincipalResultInterpreter (void)
+public setPrincipalResultInterpreter (string|int|array|null $value, int $position)
 ```
 
- 
+Set Principal ResultInterpreter (OBR.32) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 32  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1659,20 +1970,25 @@ public setPrincipalResultInterpreter (void)
 **Description**
 
 ```php
-public setPriority (void)
+public setPriority (string|int|array|null $value, int $position)
 ```
 
- 
+Set Priority (OBR.5) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 5  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1682,20 +1998,25 @@ public setPriority (void)
 **Description**
 
 ```php
-public setQuantityTiming (void)
+public setQuantityTiming (string|int|array|null $value, int $position)
 ```
 
- 
+Set Quantity Timing (OBR.27) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 27  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1705,20 +2026,25 @@ public setQuantityTiming (void)
 **Description**
 
 ```php
-public setReasonforStudy (void)
+public setReasonforStudy (string|int|array|null $value, int $position)
 ```
 
- 
+Set Reasonfor Study (OBR.31) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 31  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1728,20 +2054,25 @@ public setReasonforStudy (void)
 **Description**
 
 ```php
-public setRelevantClinicalInfo (void)
+public setRelevantClinicalInfo (string|int|array|null $value, int $position)
 ```
 
- 
+Set Relevant ClinicalInfo (OBR.13) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 13  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1751,20 +2082,25 @@ public setRelevantClinicalInfo (void)
 **Description**
 
 ```php
-public setRequestedDatetime (void)
+public setRequestedDatetime (string|int|array|null $value, int $position)
 ```
 
- 
+Set Requested Datetime (OBR.6) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 6  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1774,20 +2110,25 @@ public setRequestedDatetime (void)
 **Description**
 
 ```php
-public setResultCopiesTo (void)
+public setResultCopiesTo (string|int|array|null $value, int $position)
 ```
 
- 
+Set Result CopiesTo (OBR.28) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 28  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1797,20 +2138,25 @@ public setResultCopiesTo (void)
 **Description**
 
 ```php
-public setResultStatus (void)
+public setResultStatus (string|int|array|null $value, int $position)
 ```
 
- 
+Set Result Status (OBR.25) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 25  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1820,20 +2166,25 @@ public setResultStatus (void)
 **Description**
 
 ```php
-public setResultsRptStatusChngDateTime (void)
+public setResultsRptStatusChngDateTime (string|int|array|null $value, int $position)
 ```
 
- 
+Set Results RptStatusChngDateTime (OBR.22) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 22  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1843,20 +2194,25 @@ public setResultsRptStatusChngDateTime (void)
 **Description**
 
 ```php
-public setScheduledDateTime (void)
+public setScheduledDateTime (string|int|array|null $value, int $position)
 ```
 
- 
+Set Scheduled DateTime (OBR.36) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 36  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1866,20 +2222,25 @@ public setScheduledDateTime (void)
 **Description**
 
 ```php
-public setSpecimenActionCode (void)
+public setSpecimenActionCode (string|int|array|null $value, int $position)
 ```
 
- 
+Set Specimen ActionCode (OBR.11) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 11  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1889,20 +2250,25 @@ public setSpecimenActionCode (void)
 **Description**
 
 ```php
-public setSpecimenReceivedDateTime (void)
+public setSpecimenReceivedDateTime (string|int|array|null $value, int $position)
 ```
 
- 
+Set Specimen ReceivedDateTime (OBR.14) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 14  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1912,20 +2278,25 @@ public setSpecimenReceivedDateTime (void)
 **Description**
 
 ```php
-public setSpecimenSource (void)
+public setSpecimenSource (string|int|array|null $value, int $position)
 ```
 
- 
+Set Specimen Source (OBR.15) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 15  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1935,20 +2306,25 @@ public setSpecimenSource (void)
 **Description**
 
 ```php
-public setTechnician (void)
+public setTechnician (string|int|array|null $value, int $position)
 ```
 
- 
+Set Technician (OBR.34) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 34  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1958,20 +2334,25 @@ public setTechnician (void)
 **Description**
 
 ```php
-public setTranscriptionist (void)
+public setTranscriptionist (string|int|array|null $value, int $position)
 ```
 
- 
+Set Transcriptionist (OBR.35) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 35  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1981,20 +2362,25 @@ public setTranscriptionist (void)
 **Description**
 
 ```php
-public setTransportArranged (void)
+public setTransportArranged (string|int|array|null $value, int $position)
 ```
 
- 
+Set Transport Arranged (OBR.41) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 41  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -2004,20 +2390,25 @@ public setTransportArranged (void)
 **Description**
 
 ```php
-public setTransportArrangementResponsibility (void)
+public setTransportArrangementResponsibility (string|int|array|null $value, int $position)
 ```
 
- 
+Set Transport ArrangementResponsibility (OBR.40) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 40  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -2027,20 +2418,25 @@ public setTransportArrangementResponsibility (void)
 **Description**
 
 ```php
-public setTransportLogisticsofCollectedSample (void)
+public setTransportLogisticsofCollectedSample (string|int|array|null $value, int $position)
 ```
 
- 
+Set Transport LogisticsofCollectedSample (OBR.38) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 38  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -2050,20 +2446,25 @@ public setTransportLogisticsofCollectedSample (void)
 **Description**
 
 ```php
-public setTransportationMode (void)
+public setTransportationMode (string|int|array|null $value, int $position)
 ```
 
- 
+Set Transportation Mode (OBR.30) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 30  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -2073,20 +2474,25 @@ public setTransportationMode (void)
 **Description**
 
 ```php
-public setUniversalServiceID (void)
+public setUniversalServiceID (string|int|array|null $value, int $position)
 ```
 
- 
+Set Universal ServiceID (OBR.4) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 4  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 

--- a/docs/Segments/OBX.md
+++ b/docs/Segments/OBX.md
@@ -1,7 +1,7 @@
 # Aranyasen\HL7\Segments\OBX  
 
 OBX segment class
-Ref: https://corepointhealth.com/resource-center/hl7-resources/hl7-obx-segment
+Ref: https://hl7-definition.caristix.com/v2/HL7v2.5.1/Segments/OBX
 
 
 
@@ -13,46 +13,53 @@ Aranyasen\HL7\Segment
 
 | Name | Description |
 |------|-------------|
-|[getAbnormalFlags](#obxgetabnormalflags)||
-|[getDataLastObsNormalValues](#obxgetdatalastobsnormalvalues)||
-|[getDateTimeOfTheObservation](#obxgetdatetimeoftheobservation)||
-|[getID](#obxgetid)||
-|[getNatureOfAbnormalTest](#obxgetnatureofabnormaltest)||
-|[getObservationIdentifier](#obxgetobservationidentifier)||
-|[getObservationMethod](#obxgetobservationmethod)||
-|[getObservationSubId](#obxgetobservationsubid)||
-|[getObservationValue](#obxgetobservationvalue)||
-|[getObserveResultStatus](#obxgetobserveresultstatus)||
-|[getProbability](#obxgetprobability)||
-|[getProducersId](#obxgetproducersid)||
-|[getReferenceRange](#obxgetreferencerange)||
-|[getResponsibleObserver](#obxgetresponsibleobserver)||
-|[getUnits](#obxgetunits)||
-|[getUserDefinedAccessChecks](#obxgetuserdefinedaccesschecks)||
-|[getValueType](#obxgetvaluetype)||
-|[setAbnormalFlags](#obxsetabnormalflags)||
-|[setDataLastObsNormalValues](#obxsetdatalastobsnormalvalues)||
-|[setDateTimeOfTheObservation](#obxsetdatetimeoftheobservation)||
+|[__destruct](#obx__destruct)||
+|[getAbnormalFlags](#obxgetabnormalflags)|Get Abnormal Flags (OBR.8)|
+|[getDataLastObsNormalValues](#obxgetdatalastobsnormalvalues)|Get Data LastObsNormalValues (OBR.12)|
+|[getDateTimeOfAnalysis](#obxgetdatetimeofanalysis)|Get Date TimeOfAnalysis (OBR.19)|
+|[getDateTimeOfTheObservation](#obxgetdatetimeoftheobservation)|Get Date TimeOfTheObservation (OBR.14)|
+|[getEquipmentInstanceIdentifier](#obxgetequipmentinstanceidentifier)|Get Equipment InstanceIdentifier (OBR.18)|
+|[getID](#obxgetid)|Get ID (OBR.1)|
+|[getNatureOfAbnormalTest](#obxgetnatureofabnormaltest)|Get Nature OfAbnormalTest (OBR.10)|
+|[getObservationIdentifier](#obxgetobservationidentifier)|Get Observation Identifier (OBR.3)|
+|[getObservationMethod](#obxgetobservationmethod)|Get Observation Method (OBR.17)|
+|[getObservationSubId](#obxgetobservationsubid)|Get Observation SubId (OBR.4)|
+|[getObservationValue](#obxgetobservationvalue)|Get Observation Value (OBR.5)|
+|[getObserveResultStatus](#obxgetobserveresultstatus)|Get Observe ResultStatus (OBR.11)|
+|[getProbability](#obxgetprobability)|Get Probability (OBR.9)|
+|[getProducersId](#obxgetproducersid)|Get Producers Id (OBR.15)|
+|[getReferenceRange](#obxgetreferencerange)|Get Reference Range (OBR.7)|
+|[getResponsibleObserver](#obxgetresponsibleobserver)|Get Responsible Observer (OBR.16)|
+|[getUnits](#obxgetunits)|Get Units (OBR.6)|
+|[getUserDefinedAccessChecks](#obxgetuserdefinedaccesschecks)|Get User DefinedAccessChecks (OBR.13)|
+|[getValueType](#obxgetvaluetype)|Get Value Type (OBR.2)|
+|[resetIndex](#obxresetindex)|Reset index of this segment|
+|[setAbnormalFlags](#obxsetabnormalflags)|Set Abnormal Flags (OBR.8)|
+|[setDataLastObsNormalValues](#obxsetdatalastobsnormalvalues)|Set Data LastObsNormalValues (OBR.12)|
+|[setDateTimeOfAnalysis](#obxsetdatetimeofanalysis)|Set Date TimeOfAnalysis (OBR.19)|
+|[setDateTimeOfTheObservation](#obxsetdatetimeoftheobservation)|Set Date TimeOfTheObservation (OBR.14)|
+|[setEquipmentInstanceIdentifier](#obxsetequipmentinstanceidentifier)|Set Equipment InstanceIdentifier (OBR.18)|
 |[setID](#obxsetid)||
-|[setNatureOfAbnormalTest](#obxsetnatureofabnormaltest)||
-|[setObservationIdentifier](#obxsetobservationidentifier)||
-|[setObservationMethod](#obxsetobservationmethod)||
-|[setObservationSubId](#obxsetobservationsubid)||
-|[setObservationValue](#obxsetobservationvalue)||
-|[setObserveResultStatus](#obxsetobserveresultstatus)||
-|[setProbability](#obxsetprobability)||
-|[setProducersId](#obxsetproducersid)||
-|[setReferenceRange](#obxsetreferencerange)||
-|[setResponsibleObserver](#obxsetresponsibleobserver)||
-|[setUnits](#obxsetunits)||
-|[setUserDefinedAccessChecks](#obxsetuserdefinedaccesschecks)||
-|[setValueType](#obxsetvaluetype)||
+|[setNatureOfAbnormalTest](#obxsetnatureofabnormaltest)|Set Nature OfAbnormalTest (OBR.10)|
+|[setObservationIdentifier](#obxsetobservationidentifier)|Set Observation Identifier (OBR.3)|
+|[setObservationMethod](#obxsetobservationmethod)|Set Observation Method (OBR.17)|
+|[setObservationSubId](#obxsetobservationsubid)|Set Observation SubId (OBR.4)|
+|[setObservationValue](#obxsetobservationvalue)|Set Observation Value (OBR.5)|
+|[setObserveResultStatus](#obxsetobserveresultstatus)|Set Observe ResultStatus (OBR.11)|
+|[setProbability](#obxsetprobability)|Set Probability (OBR.9)|
+|[setProducersId](#obxsetproducersid)|Set Producers Id (OBR.15)|
+|[setReferenceRange](#obxsetreferencerange)|Set Reference Range (OBR.7)|
+|[setResponsibleObserver](#obxsetresponsibleobserver)|Set Responsible Observer (OBR.16)|
+|[setUnits](#obxsetunits)|Set Units (OBR.6)|
+|[setUserDefinedAccessChecks](#obxsetuserdefinedaccesschecks)|Set User DefinedAccessChecks (OBR.13)|
+|[setValueType](#obxsetvaluetype)|Set Value Type (OBR.2)|
 
 ## Inherited methods
 
 | Name | Description |
 |------|-------------|
 |__construct|Create a segment.|
+|clearField|Remove any existing value from the field|
 |getField|Get the field at index.|
 |getFields|Get fields from a segment|
 |getName|Get the name of the segment. This is basically the value at index 0|
@@ -61,12 +68,12 @@ Aranyasen\HL7\Segment
 
 
 
-### OBX::getAbnormalFlags  
+### OBX::__destruct  
 
 **Description**
 
 ```php
-public getAbnormalFlags (void)
+ __destruct (void)
 ```
 
  
@@ -80,6 +87,34 @@ public getAbnormalFlags (void)
 **Return Values**
 
 `void`
+
+
+<hr />
+
+
+### OBX::getAbnormalFlags  
+
+**Description**
+
+```php
+public getAbnormalFlags (int $position)
+```
+
+Get Abnormal Flags (OBR.8) 
+
+ 
+
+**Parameters**
+
+* `(int) $position`
+: Defaults to 8  
+
+**Return Values**
+
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -89,20 +124,51 @@ public getAbnormalFlags (void)
 **Description**
 
 ```php
-public getDataLastObsNormalValues (void)
+public getDataLastObsNormalValues (int $position)
 ```
 
- 
+Get Data LastObsNormalValues (OBR.12) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 12  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
+
+<hr />
+
+
+### OBX::getDateTimeOfAnalysis  
+
+**Description**
+
+```php
+public getDateTimeOfAnalysis (int $position)
+```
+
+Get Date TimeOfAnalysis (OBR.19) 
+
+ 
+
+**Parameters**
+
+* `(int) $position`
+: Defaults to 19  
+
+**Return Values**
+
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -112,20 +178,51 @@ public getDataLastObsNormalValues (void)
 **Description**
 
 ```php
-public getDateTimeOfTheObservation (void)
+public getDateTimeOfTheObservation (int $position)
 ```
 
- 
+Get Date TimeOfTheObservation (OBR.14) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 14  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
+
+<hr />
+
+
+### OBX::getEquipmentInstanceIdentifier  
+
+**Description**
+
+```php
+public getEquipmentInstanceIdentifier (int $position)
+```
+
+Get Equipment InstanceIdentifier (OBR.18) 
+
+ 
+
+**Parameters**
+
+* `(int) $position`
+: Defaults to 18  
+
+**Return Values**
+
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -135,20 +232,24 @@ public getDateTimeOfTheObservation (void)
 **Description**
 
 ```php
-public getID (void)
+public getID (int $position)
 ```
 
- 
+Get ID (OBR.1) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 1  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -158,20 +259,24 @@ public getID (void)
 **Description**
 
 ```php
-public getNatureOfAbnormalTest (void)
+public getNatureOfAbnormalTest (int $position)
 ```
 
- 
+Get Nature OfAbnormalTest (OBR.10) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 10  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -181,20 +286,24 @@ public getNatureOfAbnormalTest (void)
 **Description**
 
 ```php
-public getObservationIdentifier (void)
+public getObservationIdentifier (int $position)
 ```
 
- 
+Get Observation Identifier (OBR.3) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 3  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -204,20 +313,24 @@ public getObservationIdentifier (void)
 **Description**
 
 ```php
-public getObservationMethod (void)
+public getObservationMethod (int $position)
 ```
 
- 
+Get Observation Method (OBR.17) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 17  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -227,20 +340,24 @@ public getObservationMethod (void)
 **Description**
 
 ```php
-public getObservationSubId (void)
+public getObservationSubId (int $position)
 ```
 
- 
+Get Observation SubId (OBR.4) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 4  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -250,20 +367,24 @@ public getObservationSubId (void)
 **Description**
 
 ```php
-public getObservationValue (void)
+public getObservationValue (int $position)
 ```
 
- 
+Get Observation Value (OBR.5) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 5  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -273,20 +394,24 @@ public getObservationValue (void)
 **Description**
 
 ```php
-public getObserveResultStatus (void)
+public getObserveResultStatus (int $position)
 ```
 
- 
+Get Observe ResultStatus (OBR.11) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 11  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -296,20 +421,24 @@ public getObserveResultStatus (void)
 **Description**
 
 ```php
-public getProbability (void)
+public getProbability (int $position)
 ```
 
- 
+Get Probability (OBR.9) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 9  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -319,20 +448,24 @@ public getProbability (void)
 **Description**
 
 ```php
-public getProducersId (void)
+public getProducersId (int $position)
 ```
 
- 
+Get Producers Id (OBR.15) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 15  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -342,20 +475,24 @@ public getProducersId (void)
 **Description**
 
 ```php
-public getReferenceRange (void)
+public getReferenceRange (int $position)
 ```
 
- 
+Get Reference Range (OBR.7) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 7  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -365,20 +502,24 @@ public getReferenceRange (void)
 **Description**
 
 ```php
-public getResponsibleObserver (void)
+public getResponsibleObserver (int $position)
 ```
 
- 
+Get Responsible Observer (OBR.16) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 16  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -388,20 +529,24 @@ public getResponsibleObserver (void)
 **Description**
 
 ```php
-public getUnits (void)
+public getUnits (int $position)
 ```
 
- 
+Get Units (OBR.6) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 6  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -411,20 +556,24 @@ public getUnits (void)
 **Description**
 
 ```php
-public getUserDefinedAccessChecks (void)
+public getUserDefinedAccessChecks (int $position)
 ```
 
- 
+Get User DefinedAccessChecks (OBR.13) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 13  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -434,10 +583,37 @@ public getUserDefinedAccessChecks (void)
 **Description**
 
 ```php
-public getValueType (void)
+public getValueType (int $position)
 ```
 
+Get Value Type (OBR.2) 
+
  
+
+**Parameters**
+
+* `(int) $position`
+: Defaults to 2  
+
+**Return Values**
+
+`array|string|int|null`
+
+
+
+
+<hr />
+
+
+### OBX::resetIndex  
+
+**Description**
+
+```php
+public static resetIndex (void)
+```
+
+Reset index of this segment 
 
  
 
@@ -448,6 +624,7 @@ public getValueType (void)
 **Return Values**
 
 `void`
+
 
 <hr />
 
@@ -457,20 +634,25 @@ public getValueType (void)
 **Description**
 
 ```php
-public setAbnormalFlags (void)
+public setAbnormalFlags (string|int|array|null $value, int $position)
 ```
 
- 
+Set Abnormal Flags (OBR.8) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 8  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -480,20 +662,53 @@ public setAbnormalFlags (void)
 **Description**
 
 ```php
-public setDataLastObsNormalValues (void)
+public setDataLastObsNormalValues (string|int|array|null $value, int $position)
 ```
 
- 
+Set Data LastObsNormalValues (OBR.12) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 12  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
+
+<hr />
+
+
+### OBX::setDateTimeOfAnalysis  
+
+**Description**
+
+```php
+public setDateTimeOfAnalysis (string|int|array|null $value, int $position)
+```
+
+Set Date TimeOfAnalysis (OBR.19) 
+
+ 
+
+**Parameters**
+
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 19  
+
+**Return Values**
+
+`bool`
+
+
+
 
 <hr />
 
@@ -503,20 +718,53 @@ public setDataLastObsNormalValues (void)
 **Description**
 
 ```php
-public setDateTimeOfTheObservation (void)
+public setDateTimeOfTheObservation (string|int|array|null $value, int $position)
 ```
 
- 
+Set Date TimeOfTheObservation (OBR.14) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 14  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
+
+<hr />
+
+
+### OBX::setEquipmentInstanceIdentifier  
+
+**Description**
+
+```php
+public setEquipmentInstanceIdentifier (string|int|array|null $value, int $position)
+```
+
+Set Equipment InstanceIdentifier (OBR.18) 
+
+ 
+
+**Parameters**
+
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 18  
+
+**Return Values**
+
+`bool`
+
+
+
 
 <hr />
 
@@ -526,7 +774,7 @@ public setDateTimeOfTheObservation (void)
 **Description**
 
 ```php
-public setID (void)
+ setID (void)
 ```
 
  
@@ -540,6 +788,7 @@ public setID (void)
 **Return Values**
 
 `void`
+
 
 <hr />
 
@@ -549,20 +798,25 @@ public setID (void)
 **Description**
 
 ```php
-public setNatureOfAbnormalTest (void)
+public setNatureOfAbnormalTest (string|int|array|null $value, int $position)
 ```
 
- 
+Set Nature OfAbnormalTest (OBR.10) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 10  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -572,20 +826,25 @@ public setNatureOfAbnormalTest (void)
 **Description**
 
 ```php
-public setObservationIdentifier (void)
+public setObservationIdentifier (string|int|array|null $value, int $position)
 ```
 
- 
+Set Observation Identifier (OBR.3) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 3  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -595,20 +854,25 @@ public setObservationIdentifier (void)
 **Description**
 
 ```php
-public setObservationMethod (void)
+public setObservationMethod (string|int|array|null $value, int $position)
 ```
 
- 
+Set Observation Method (OBR.17) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 17  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -618,20 +882,25 @@ public setObservationMethod (void)
 **Description**
 
 ```php
-public setObservationSubId (void)
+public setObservationSubId (string|int|array|null $value, int $position)
 ```
 
- 
+Set Observation SubId (OBR.4) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 4  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -641,20 +910,25 @@ public setObservationSubId (void)
 **Description**
 
 ```php
-public setObservationValue (void)
+public setObservationValue (string|int|array|null $value, int $position)
 ```
 
- 
+Set Observation Value (OBR.5) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 5  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -664,20 +938,25 @@ public setObservationValue (void)
 **Description**
 
 ```php
-public setObserveResultStatus (void)
+public setObserveResultStatus (string|int|array|null $value, int $position)
 ```
 
- 
+Set Observe ResultStatus (OBR.11) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 11  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -687,20 +966,25 @@ public setObserveResultStatus (void)
 **Description**
 
 ```php
-public setProbability (void)
+public setProbability (string|int|array|null $value, int $position)
 ```
 
- 
+Set Probability (OBR.9) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 9  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -710,20 +994,25 @@ public setProbability (void)
 **Description**
 
 ```php
-public setProducersId (void)
+public setProducersId (string|int|array|null $value, int $position)
 ```
 
- 
+Set Producers Id (OBR.15) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 15  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -733,20 +1022,25 @@ public setProducersId (void)
 **Description**
 
 ```php
-public setReferenceRange (void)
+public setReferenceRange (string|int|array|null $value, int $position)
 ```
 
- 
+Set Reference Range (OBR.7) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 7  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -756,20 +1050,25 @@ public setReferenceRange (void)
 **Description**
 
 ```php
-public setResponsibleObserver (void)
+public setResponsibleObserver (string|int|array|null $value, int $position)
 ```
 
- 
+Set Responsible Observer (OBR.16) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 16  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -779,20 +1078,25 @@ public setResponsibleObserver (void)
 **Description**
 
 ```php
-public setUnits (void)
+public setUnits (string|int|array|null $value, int $position)
 ```
 
- 
+Set Units (OBR.6) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 6  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -802,20 +1106,25 @@ public setUnits (void)
 **Description**
 
 ```php
-public setUserDefinedAccessChecks (void)
+public setUserDefinedAccessChecks (string|int|array|null $value, int $position)
 ```
 
- 
+Set User DefinedAccessChecks (OBR.13) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 13  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -825,20 +1134,25 @@ public setUserDefinedAccessChecks (void)
 **Description**
 
 ```php
-public setValueType (void)
+public setValueType (string|int|array|null $value, int $position)
 ```
 
- 
+Set Value Type (OBR.2) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 2  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 

--- a/docs/Segments/ORC.md
+++ b/docs/Segments/ORC.md
@@ -13,74 +13,75 @@ Aranyasen\HL7\Segment
 
 | Name | Description |
 |------|-------------|
-|[getActionBy](#orcgetactionby)||
-|[getAdvancedBeneficiaryNoticeCode](#orcgetadvancedbeneficiarynoticecode)||
-|[getAdvancedBeneficiaryNoticeOverrideReason](#orcgetadvancedbeneficiarynoticeoverridereason)||
-|[getCallBackPhoneNumber](#orcgetcallbackphonenumber)||
-|[getConfidentialityCode](#orcgetconfidentialitycode)||
-|[getDateTimeofTransaction](#orcgetdatetimeoftransaction)||
-|[getEnteredBy](#orcgetenteredby)||
-|[getEntererAuthorizationMode](#orcgetentererauthorizationmode)||
-|[getEnterersLocation](#orcgetentererslocation)||
-|[getEnteringDevice](#orcgetenteringdevice)||
-|[getEnteringOrganization](#orcgetenteringorganization)||
-|[getFillerOrderNumber](#orcgetfillerordernumber)||
-|[getFillersExpectedAvailabilityDateTime](#orcgetfillersexpectedavailabilitydatetime)||
-|[getOrderControl](#orcgetordercontrol)||
-|[getOrderControlCodeReason](#orcgetordercontrolcodereason)||
-|[getOrderEffectiveDateTime](#orcgetordereffectivedatetime)||
-|[getOrderStatus](#orcgetorderstatus)||
-|[getOrderStatusModifier](#orcgetorderstatusmodifier)||
-|[getOrderType](#orcgetordertype)||
-|[getOrderingFacilityAddress](#orcgetorderingfacilityaddress)||
-|[getOrderingFacilityName](#orcgetorderingfacilityname)||
-|[getOrderingFacilityPhoneNumber](#orcgetorderingfacilityphonenumber)||
-|[getOrderingProvider](#orcgetorderingprovider)||
-|[getOrderingProviderAddress](#orcgetorderingprovideraddress)||
-|[getParentOrder](#orcgetparentorder)||
-|[getParentUniversalServiceIdentifier](#orcgetparentuniversalserviceidentifier)||
-|[getPlacerGroupNumber](#orcgetplacergroupnumber)||
-|[getPlacerOrderNumber](#orcgetplacerordernumber)||
-|[getQuantityTiming](#orcgetquantitytiming)||
-|[getResponseFlag](#orcgetresponseflag)||
-|[getVerifiedBy](#orcgetverifiedby)||
-|[setActionBy](#orcsetactionby)||
-|[setAdvancedBeneficiaryNoticeCode](#orcsetadvancedbeneficiarynoticecode)||
-|[setAdvancedBeneficiaryNoticeOverrideReason](#orcsetadvancedbeneficiarynoticeoverridereason)||
-|[setCallBackPhoneNumber](#orcsetcallbackphonenumber)||
-|[setConfidentialityCode](#orcsetconfidentialitycode)||
-|[setDateTimeofTransaction](#orcsetdatetimeoftransaction)||
-|[setEnteredBy](#orcsetenteredby)||
-|[setEntererAuthorizationMode](#orcsetentererauthorizationmode)||
-|[setEnterersLocation](#orcsetentererslocation)||
-|[setEnteringDevice](#orcsetenteringdevice)||
-|[setEnteringOrganization](#orcsetenteringorganization)||
-|[setFillerOrderNumber](#orcsetfillerordernumber)||
-|[setFillersExpectedAvailabilityDateTime](#orcsetfillersexpectedavailabilitydatetime)||
-|[setOrderControl](#orcsetordercontrol)||
-|[setOrderControlCodeReason](#orcsetordercontrolcodereason)||
-|[setOrderEffectiveDateTime](#orcsetordereffectivedatetime)||
-|[setOrderStatus](#orcsetorderstatus)||
-|[setOrderStatusModifier](#orcsetorderstatusmodifier)||
-|[setOrderType](#orcsetordertype)||
-|[setOrderingFacilityAddress](#orcsetorderingfacilityaddress)||
-|[setOrderingFacilityName](#orcsetorderingfacilityname)||
-|[setOrderingFacilityPhoneNumber](#orcsetorderingfacilityphonenumber)||
-|[setOrderingProvider](#orcsetorderingprovider)||
-|[setOrderingProviderAddress](#orcsetorderingprovideraddress)||
-|[setParentOrder](#orcsetparentorder)||
-|[setParentUniversalServiceIdentifier](#orcsetparentuniversalserviceidentifier)||
-|[setPlacerGroupNumber](#orcsetplacergroupnumber)||
-|[setPlacerOrderNumber](#orcsetplacerordernumber)||
-|[setQuantityTiming](#orcsetquantitytiming)||
-|[setResponseFlag](#orcsetresponseflag)||
-|[setVerifiedBy](#orcsetverifiedby)||
+|[getActionBy](#orcgetactionby)|Get Action By (OBR.19)|
+|[getAdvancedBeneficiaryNoticeCode](#orcgetadvancedbeneficiarynoticecode)|Get Advanced BeneficiaryNoticeCode (OBR.20)|
+|[getAdvancedBeneficiaryNoticeOverrideReason](#orcgetadvancedbeneficiarynoticeoverridereason)|Get Advanced BeneficiaryNoticeOverrideReason (OBR.26)|
+|[getCallBackPhoneNumber](#orcgetcallbackphonenumber)|Get Call BackPhoneNumber (OBR.14)|
+|[getConfidentialityCode](#orcgetconfidentialitycode)|Get Confidentiality Code (OBR.28)|
+|[getDateTimeofTransaction](#orcgetdatetimeoftransaction)|Get Date TimeofTransaction (OBR.9)|
+|[getEnteredBy](#orcgetenteredby)|Get Entered By (OBR.10)|
+|[getEntererAuthorizationMode](#orcgetentererauthorizationmode)|Get Enterer AuthorizationMode (OBR.30)|
+|[getEnterersLocation](#orcgetentererslocation)|Get Enterers Location (OBR.13)|
+|[getEnteringDevice](#orcgetenteringdevice)|Get Entering Device (OBR.18)|
+|[getEnteringOrganization](#orcgetenteringorganization)|Get Entering Organization (OBR.17)|
+|[getFillerOrderNumber](#orcgetfillerordernumber)|Get Filler OrderNumber (OBR.3)|
+|[getFillersExpectedAvailabilityDateTime](#orcgetfillersexpectedavailabilitydatetime)|Get Fillers ExpectedAvailabilityDateTime (OBR.27)|
+|[getOrderControl](#orcgetordercontrol)|Get Order Control (OBR.1)|
+|[getOrderControlCodeReason](#orcgetordercontrolcodereason)|Get Order ControlCodeReason (OBR.16)|
+|[getOrderEffectiveDateTime](#orcgetordereffectivedatetime)|Get Order EffectiveDateTime (OBR.15)|
+|[getOrderStatus](#orcgetorderstatus)|Get Order Status (OBR.5)|
+|[getOrderStatusModifier](#orcgetorderstatusmodifier)|Get Order StatusModifier (OBR.25)|
+|[getOrderType](#orcgetordertype)|Get Order Type (OBR.29)|
+|[getOrderingFacilityAddress](#orcgetorderingfacilityaddress)|Get Ordering FacilityAddress (OBR.22)|
+|[getOrderingFacilityName](#orcgetorderingfacilityname)|Get Ordering FacilityName (OBR.21)|
+|[getOrderingFacilityPhoneNumber](#orcgetorderingfacilityphonenumber)|Get Ordering FacilityPhoneNumber (OBR.23)|
+|[getOrderingProvider](#orcgetorderingprovider)|Get Ordering Provider (OBR.12)|
+|[getOrderingProviderAddress](#orcgetorderingprovideraddress)|Get Ordering ProviderAddress (OBR.24)|
+|[getParentOrder](#orcgetparentorder)|Get Parent Order (OBR.8)|
+|[getParentUniversalServiceIdentifier](#orcgetparentuniversalserviceidentifier)|Get Parent UniversalServiceIdentifier (OBR.31)|
+|[getPlacerGroupNumber](#orcgetplacergroupnumber)|Get Placer GroupNumber (OBR.4)|
+|[getPlacerOrderNumber](#orcgetplacerordernumber)|Get Placer OrderNumber (OBR.2)|
+|[getQuantityTiming](#orcgetquantitytiming)|Get Quantity Timing (OBR.7)|
+|[getResponseFlag](#orcgetresponseflag)|Get Response Flag (OBR.6)|
+|[getVerifiedBy](#orcgetverifiedby)|Get Verified By (OBR.11)|
+|[setActionBy](#orcsetactionby)|Set Action By (OBR.19)|
+|[setAdvancedBeneficiaryNoticeCode](#orcsetadvancedbeneficiarynoticecode)|Set Advanced BeneficiaryNoticeCode (OBR.20)|
+|[setAdvancedBeneficiaryNoticeOverrideReason](#orcsetadvancedbeneficiarynoticeoverridereason)|Set Advanced BeneficiaryNoticeOverrideReason (OBR.26)|
+|[setCallBackPhoneNumber](#orcsetcallbackphonenumber)|Set Call BackPhoneNumber (OBR.14)|
+|[setConfidentialityCode](#orcsetconfidentialitycode)|Set Confidentiality Code (OBR.28)|
+|[setDateTimeofTransaction](#orcsetdatetimeoftransaction)|Set Date TimeofTransaction (OBR.9)|
+|[setEnteredBy](#orcsetenteredby)|Set Entered By (OBR.10)|
+|[setEntererAuthorizationMode](#orcsetentererauthorizationmode)|Set Enterer AuthorizationMode (OBR.30)|
+|[setEnterersLocation](#orcsetentererslocation)|Set Enterers Location (OBR.13)|
+|[setEnteringDevice](#orcsetenteringdevice)|Set Entering Device (OBR.18)|
+|[setEnteringOrganization](#orcsetenteringorganization)|Set Entering Organization (OBR.17)|
+|[setFillerOrderNumber](#orcsetfillerordernumber)|Set Filler OrderNumber (OBR.3)|
+|[setFillersExpectedAvailabilityDateTime](#orcsetfillersexpectedavailabilitydatetime)|Set Fillers ExpectedAvailabilityDateTime (OBR.27)|
+|[setOrderControl](#orcsetordercontrol)|Set Order Control (OBR.1)|
+|[setOrderControlCodeReason](#orcsetordercontrolcodereason)|Set Order ControlCodeReason (OBR.16)|
+|[setOrderEffectiveDateTime](#orcsetordereffectivedatetime)|Set Order EffectiveDateTime (OBR.15)|
+|[setOrderStatus](#orcsetorderstatus)|Set Order Status (OBR.5)|
+|[setOrderStatusModifier](#orcsetorderstatusmodifier)|Set Order StatusModifier (OBR.25)|
+|[setOrderType](#orcsetordertype)|Set Order Type (OBR.29)|
+|[setOrderingFacilityAddress](#orcsetorderingfacilityaddress)|Set Ordering FacilityAddress (OBR.22)|
+|[setOrderingFacilityName](#orcsetorderingfacilityname)|Set Ordering FacilityName (OBR.21)|
+|[setOrderingFacilityPhoneNumber](#orcsetorderingfacilityphonenumber)|Set Ordering FacilityPhoneNumber (OBR.23)|
+|[setOrderingProvider](#orcsetorderingprovider)|Set Ordering Provider (OBR.12)|
+|[setOrderingProviderAddress](#orcsetorderingprovideraddress)|Set Ordering ProviderAddress (OBR.24)|
+|[setParentOrder](#orcsetparentorder)|Set Parent Order (OBR.8)|
+|[setParentUniversalServiceIdentifier](#orcsetparentuniversalserviceidentifier)|Set Parent UniversalServiceIdentifier (OBR.31)|
+|[setPlacerGroupNumber](#orcsetplacergroupnumber)|Set Placer GroupNumber (OBR.4)|
+|[setPlacerOrderNumber](#orcsetplacerordernumber)|Set Placer OrderNumber (OBR.2)|
+|[setQuantityTiming](#orcsetquantitytiming)|Set Quantity Timing (OBR.7)|
+|[setResponseFlag](#orcsetresponseflag)|Set Response Flag (OBR.6)|
+|[setVerifiedBy](#orcsetverifiedby)|Set Verified By (OBR.11)|
 
 ## Inherited methods
 
 | Name | Description |
 |------|-------------|
 |__construct|Create a segment.|
+|clearField|Remove any existing value from the field|
 |getField|Get the field at index.|
 |getFields|Get fields from a segment|
 |getName|Get the name of the segment. This is basically the value at index 0|
@@ -94,20 +95,24 @@ Aranyasen\HL7\Segment
 **Description**
 
 ```php
-public getActionBy (void)
+public getActionBy (int $position)
 ```
 
- 
+Get Action By (OBR.19) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 19  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -117,20 +122,24 @@ public getActionBy (void)
 **Description**
 
 ```php
-public getAdvancedBeneficiaryNoticeCode (void)
+public getAdvancedBeneficiaryNoticeCode (int $position)
 ```
 
- 
+Get Advanced BeneficiaryNoticeCode (OBR.20) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 20  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -140,20 +149,24 @@ public getAdvancedBeneficiaryNoticeCode (void)
 **Description**
 
 ```php
-public getAdvancedBeneficiaryNoticeOverrideReason (void)
+public getAdvancedBeneficiaryNoticeOverrideReason (int $position)
 ```
 
- 
+Get Advanced BeneficiaryNoticeOverrideReason (OBR.26) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 26  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -163,20 +176,24 @@ public getAdvancedBeneficiaryNoticeOverrideReason (void)
 **Description**
 
 ```php
-public getCallBackPhoneNumber (void)
+public getCallBackPhoneNumber (int $position)
 ```
 
- 
+Get Call BackPhoneNumber (OBR.14) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 14  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -186,20 +203,24 @@ public getCallBackPhoneNumber (void)
 **Description**
 
 ```php
-public getConfidentialityCode (void)
+public getConfidentialityCode (int $position)
 ```
 
- 
+Get Confidentiality Code (OBR.28) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 28  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -209,20 +230,24 @@ public getConfidentialityCode (void)
 **Description**
 
 ```php
-public getDateTimeofTransaction (void)
+public getDateTimeofTransaction (int $position)
 ```
 
- 
+Get Date TimeofTransaction (OBR.9) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 9  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -232,20 +257,24 @@ public getDateTimeofTransaction (void)
 **Description**
 
 ```php
-public getEnteredBy (void)
+public getEnteredBy (int $position)
 ```
 
- 
+Get Entered By (OBR.10) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 10  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -255,20 +284,24 @@ public getEnteredBy (void)
 **Description**
 
 ```php
-public getEntererAuthorizationMode (void)
+public getEntererAuthorizationMode (int $position)
 ```
 
- 
+Get Enterer AuthorizationMode (OBR.30) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 30  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -278,20 +311,24 @@ public getEntererAuthorizationMode (void)
 **Description**
 
 ```php
-public getEnterersLocation (void)
+public getEnterersLocation (int $position)
 ```
 
- 
+Get Enterers Location (OBR.13) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 13  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -301,20 +338,24 @@ public getEnterersLocation (void)
 **Description**
 
 ```php
-public getEnteringDevice (void)
+public getEnteringDevice (int $position)
 ```
 
- 
+Get Entering Device (OBR.18) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 18  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -324,20 +365,24 @@ public getEnteringDevice (void)
 **Description**
 
 ```php
-public getEnteringOrganization (void)
+public getEnteringOrganization (int $position)
 ```
 
- 
+Get Entering Organization (OBR.17) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 17  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -347,20 +392,24 @@ public getEnteringOrganization (void)
 **Description**
 
 ```php
-public getFillerOrderNumber (void)
+public getFillerOrderNumber (int $position)
 ```
 
- 
+Get Filler OrderNumber (OBR.3) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 3  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -370,20 +419,24 @@ public getFillerOrderNumber (void)
 **Description**
 
 ```php
-public getFillersExpectedAvailabilityDateTime (void)
+public getFillersExpectedAvailabilityDateTime (int $position)
 ```
 
- 
+Get Fillers ExpectedAvailabilityDateTime (OBR.27) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 27  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -393,20 +446,24 @@ public getFillersExpectedAvailabilityDateTime (void)
 **Description**
 
 ```php
-public getOrderControl (void)
+public getOrderControl (int $position)
 ```
 
- 
+Get Order Control (OBR.1) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 1  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -416,20 +473,24 @@ public getOrderControl (void)
 **Description**
 
 ```php
-public getOrderControlCodeReason (void)
+public getOrderControlCodeReason (int $position)
 ```
 
- 
+Get Order ControlCodeReason (OBR.16) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 16  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -439,20 +500,24 @@ public getOrderControlCodeReason (void)
 **Description**
 
 ```php
-public getOrderEffectiveDateTime (void)
+public getOrderEffectiveDateTime (int $position)
 ```
 
- 
+Get Order EffectiveDateTime (OBR.15) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 15  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -462,20 +527,24 @@ public getOrderEffectiveDateTime (void)
 **Description**
 
 ```php
-public getOrderStatus (void)
+public getOrderStatus (int $position)
 ```
 
- 
+Get Order Status (OBR.5) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 5  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -485,20 +554,24 @@ public getOrderStatus (void)
 **Description**
 
 ```php
-public getOrderStatusModifier (void)
+public getOrderStatusModifier (int $position)
 ```
 
- 
+Get Order StatusModifier (OBR.25) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 25  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -508,20 +581,24 @@ public getOrderStatusModifier (void)
 **Description**
 
 ```php
-public getOrderType (void)
+public getOrderType (int $position)
 ```
 
- 
+Get Order Type (OBR.29) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 29  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -531,20 +608,24 @@ public getOrderType (void)
 **Description**
 
 ```php
-public getOrderingFacilityAddress (void)
+public getOrderingFacilityAddress (int $position)
 ```
 
- 
+Get Ordering FacilityAddress (OBR.22) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 22  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -554,20 +635,24 @@ public getOrderingFacilityAddress (void)
 **Description**
 
 ```php
-public getOrderingFacilityName (void)
+public getOrderingFacilityName (int $position)
 ```
 
- 
+Get Ordering FacilityName (OBR.21) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 21  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -577,20 +662,24 @@ public getOrderingFacilityName (void)
 **Description**
 
 ```php
-public getOrderingFacilityPhoneNumber (void)
+public getOrderingFacilityPhoneNumber (int $position)
 ```
 
- 
+Get Ordering FacilityPhoneNumber (OBR.23) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 23  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -600,20 +689,24 @@ public getOrderingFacilityPhoneNumber (void)
 **Description**
 
 ```php
-public getOrderingProvider (void)
+public getOrderingProvider (int $position)
 ```
 
- 
+Get Ordering Provider (OBR.12) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 12  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -623,20 +716,24 @@ public getOrderingProvider (void)
 **Description**
 
 ```php
-public getOrderingProviderAddress (void)
+public getOrderingProviderAddress (int $position)
 ```
 
- 
+Get Ordering ProviderAddress (OBR.24) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 24  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -646,20 +743,24 @@ public getOrderingProviderAddress (void)
 **Description**
 
 ```php
-public getParentOrder (void)
+public getParentOrder (int $position)
 ```
 
- 
+Get Parent Order (OBR.8) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 8  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -669,20 +770,24 @@ public getParentOrder (void)
 **Description**
 
 ```php
-public getParentUniversalServiceIdentifier (void)
+public getParentUniversalServiceIdentifier (int $position)
 ```
 
- 
+Get Parent UniversalServiceIdentifier (OBR.31) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 31  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -692,20 +797,24 @@ public getParentUniversalServiceIdentifier (void)
 **Description**
 
 ```php
-public getPlacerGroupNumber (void)
+public getPlacerGroupNumber (int $position)
 ```
 
- 
+Get Placer GroupNumber (OBR.4) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 4  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -715,20 +824,24 @@ public getPlacerGroupNumber (void)
 **Description**
 
 ```php
-public getPlacerOrderNumber (void)
+public getPlacerOrderNumber (int $position)
 ```
 
- 
+Get Placer OrderNumber (OBR.2) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 2  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -738,20 +851,24 @@ public getPlacerOrderNumber (void)
 **Description**
 
 ```php
-public getQuantityTiming (void)
+public getQuantityTiming (int $position)
 ```
 
- 
+Get Quantity Timing (OBR.7) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 7  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -761,20 +878,24 @@ public getQuantityTiming (void)
 **Description**
 
 ```php
-public getResponseFlag (void)
+public getResponseFlag (int $position)
 ```
 
- 
+Get Response Flag (OBR.6) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 6  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -784,20 +905,24 @@ public getResponseFlag (void)
 **Description**
 
 ```php
-public getVerifiedBy (void)
+public getVerifiedBy (int $position)
 ```
 
- 
+Get Verified By (OBR.11) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 11  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -807,20 +932,25 @@ public getVerifiedBy (void)
 **Description**
 
 ```php
-public setActionBy (void)
+public setActionBy (string|int|array|null $value, int $position)
 ```
 
- 
+Set Action By (OBR.19) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 19  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -830,20 +960,25 @@ public setActionBy (void)
 **Description**
 
 ```php
-public setAdvancedBeneficiaryNoticeCode (void)
+public setAdvancedBeneficiaryNoticeCode (string|int|array|null $value, int $position)
 ```
 
- 
+Set Advanced BeneficiaryNoticeCode (OBR.20) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 20  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -853,20 +988,25 @@ public setAdvancedBeneficiaryNoticeCode (void)
 **Description**
 
 ```php
-public setAdvancedBeneficiaryNoticeOverrideReason (void)
+public setAdvancedBeneficiaryNoticeOverrideReason (string|int|array|null $value, int $position)
 ```
 
- 
+Set Advanced BeneficiaryNoticeOverrideReason (OBR.26) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 26  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -876,20 +1016,25 @@ public setAdvancedBeneficiaryNoticeOverrideReason (void)
 **Description**
 
 ```php
-public setCallBackPhoneNumber (void)
+public setCallBackPhoneNumber (string|int|array|null $value, int $position)
 ```
 
- 
+Set Call BackPhoneNumber (OBR.14) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 14  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -899,20 +1044,25 @@ public setCallBackPhoneNumber (void)
 **Description**
 
 ```php
-public setConfidentialityCode (void)
+public setConfidentialityCode (string|int|array|null $value, int $position)
 ```
 
- 
+Set Confidentiality Code (OBR.28) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 28  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -922,20 +1072,25 @@ public setConfidentialityCode (void)
 **Description**
 
 ```php
-public setDateTimeofTransaction (void)
+public setDateTimeofTransaction (string|int|array|null $value, int $position)
 ```
 
- 
+Set Date TimeofTransaction (OBR.9) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 9  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -945,20 +1100,25 @@ public setDateTimeofTransaction (void)
 **Description**
 
 ```php
-public setEnteredBy (void)
+public setEnteredBy (string|int|array|null $value, int $position)
 ```
 
- 
+Set Entered By (OBR.10) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 10  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -968,20 +1128,25 @@ public setEnteredBy (void)
 **Description**
 
 ```php
-public setEntererAuthorizationMode (void)
+public setEntererAuthorizationMode (string|int|array|null $value, int $position)
 ```
 
- 
+Set Enterer AuthorizationMode (OBR.30) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 30  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -991,20 +1156,25 @@ public setEntererAuthorizationMode (void)
 **Description**
 
 ```php
-public setEnterersLocation (void)
+public setEnterersLocation (string|int|array|null $value, int $position)
 ```
 
- 
+Set Enterers Location (OBR.13) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 13  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1014,20 +1184,25 @@ public setEnterersLocation (void)
 **Description**
 
 ```php
-public setEnteringDevice (void)
+public setEnteringDevice (string|int|array|null $value, int $position)
 ```
 
- 
+Set Entering Device (OBR.18) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 18  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1037,20 +1212,25 @@ public setEnteringDevice (void)
 **Description**
 
 ```php
-public setEnteringOrganization (void)
+public setEnteringOrganization (string|int|array|null $value, int $position)
 ```
 
- 
+Set Entering Organization (OBR.17) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 17  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1060,20 +1240,25 @@ public setEnteringOrganization (void)
 **Description**
 
 ```php
-public setFillerOrderNumber (void)
+public setFillerOrderNumber (string|int|array|null $value, int $position)
 ```
 
- 
+Set Filler OrderNumber (OBR.3) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 3  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1083,20 +1268,25 @@ public setFillerOrderNumber (void)
 **Description**
 
 ```php
-public setFillersExpectedAvailabilityDateTime (void)
+public setFillersExpectedAvailabilityDateTime (string|int|array|null $value, int $position)
 ```
 
- 
+Set Fillers ExpectedAvailabilityDateTime (OBR.27) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 27  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1106,20 +1296,25 @@ public setFillersExpectedAvailabilityDateTime (void)
 **Description**
 
 ```php
-public setOrderControl (void)
+public setOrderControl (string|int|array|null $value, int $position)
 ```
 
- 
+Set Order Control (OBR.1) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 1  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1129,20 +1324,25 @@ public setOrderControl (void)
 **Description**
 
 ```php
-public setOrderControlCodeReason (void)
+public setOrderControlCodeReason (string|int|array|null $value, int $position)
 ```
 
- 
+Set Order ControlCodeReason (OBR.16) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 16  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1152,20 +1352,25 @@ public setOrderControlCodeReason (void)
 **Description**
 
 ```php
-public setOrderEffectiveDateTime (void)
+public setOrderEffectiveDateTime (string|int|array|null $value, int $position)
 ```
 
- 
+Set Order EffectiveDateTime (OBR.15) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 15  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1175,20 +1380,25 @@ public setOrderEffectiveDateTime (void)
 **Description**
 
 ```php
-public setOrderStatus (void)
+public setOrderStatus (string|int|array|null $value, int $position)
 ```
 
- 
+Set Order Status (OBR.5) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 5  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1198,20 +1408,25 @@ public setOrderStatus (void)
 **Description**
 
 ```php
-public setOrderStatusModifier (void)
+public setOrderStatusModifier (string|int|array|null $value, int $position)
 ```
 
- 
+Set Order StatusModifier (OBR.25) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 25  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1221,20 +1436,25 @@ public setOrderStatusModifier (void)
 **Description**
 
 ```php
-public setOrderType (void)
+public setOrderType (string|int|array|null $value, int $position)
 ```
 
- 
+Set Order Type (OBR.29) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 29  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1244,20 +1464,25 @@ public setOrderType (void)
 **Description**
 
 ```php
-public setOrderingFacilityAddress (void)
+public setOrderingFacilityAddress (string|int|array|null $value, int $position)
 ```
 
- 
+Set Ordering FacilityAddress (OBR.22) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 22  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1267,20 +1492,25 @@ public setOrderingFacilityAddress (void)
 **Description**
 
 ```php
-public setOrderingFacilityName (void)
+public setOrderingFacilityName (string|int|array|null $value, int $position)
 ```
 
- 
+Set Ordering FacilityName (OBR.21) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 21  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1290,20 +1520,25 @@ public setOrderingFacilityName (void)
 **Description**
 
 ```php
-public setOrderingFacilityPhoneNumber (void)
+public setOrderingFacilityPhoneNumber (string|int|array|null $value, int $position)
 ```
 
- 
+Set Ordering FacilityPhoneNumber (OBR.23) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 23  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1313,20 +1548,25 @@ public setOrderingFacilityPhoneNumber (void)
 **Description**
 
 ```php
-public setOrderingProvider (void)
+public setOrderingProvider (string|int|array|null $value, int $position)
 ```
 
- 
+Set Ordering Provider (OBR.12) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 12  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1336,20 +1576,25 @@ public setOrderingProvider (void)
 **Description**
 
 ```php
-public setOrderingProviderAddress (void)
+public setOrderingProviderAddress (string|int|array|null $value, int $position)
 ```
 
- 
+Set Ordering ProviderAddress (OBR.24) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 24  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1359,20 +1604,25 @@ public setOrderingProviderAddress (void)
 **Description**
 
 ```php
-public setParentOrder (void)
+public setParentOrder (string|int|array|null $value, int $position)
 ```
 
- 
+Set Parent Order (OBR.8) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 8  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1382,20 +1632,25 @@ public setParentOrder (void)
 **Description**
 
 ```php
-public setParentUniversalServiceIdentifier (void)
+public setParentUniversalServiceIdentifier (string|int|array|null $value, int $position)
 ```
 
- 
+Set Parent UniversalServiceIdentifier (OBR.31) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 31  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1405,20 +1660,25 @@ public setParentUniversalServiceIdentifier (void)
 **Description**
 
 ```php
-public setPlacerGroupNumber (void)
+public setPlacerGroupNumber (string|int|array|null $value, int $position)
 ```
 
- 
+Set Placer GroupNumber (OBR.4) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 4  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1428,20 +1688,25 @@ public setPlacerGroupNumber (void)
 **Description**
 
 ```php
-public setPlacerOrderNumber (void)
+public setPlacerOrderNumber (string|int|array|null $value, int $position)
 ```
 
- 
+Set Placer OrderNumber (OBR.2) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 2  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1451,20 +1716,25 @@ public setPlacerOrderNumber (void)
 **Description**
 
 ```php
-public setQuantityTiming (void)
+public setQuantityTiming (string|int|array|null $value, int $position)
 ```
 
- 
+Set Quantity Timing (OBR.7) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 7  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1474,20 +1744,25 @@ public setQuantityTiming (void)
 **Description**
 
 ```php
-public setResponseFlag (void)
+public setResponseFlag (string|int|array|null $value, int $position)
 ```
 
- 
+Set Response Flag (OBR.6) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 6  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1497,20 +1772,25 @@ public setResponseFlag (void)
 **Description**
 
 ```php
-public setVerifiedBy (void)
+public setVerifiedBy (string|int|array|null $value, int $position)
 ```
 
- 
+Set Verified By (OBR.11) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 11  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 

--- a/docs/Segments/PID.md
+++ b/docs/Segments/PID.md
@@ -1,6 +1,7 @@
 # Aranyasen\HL7\Segments\PID  
 
 PID segment class
+Reference: https://corepointhealth.com/resource-center/hl7-resources/hl7-pid-segment
 
 
 
@@ -12,72 +13,75 @@ Aranyasen\HL7\Segment
 
 | Name | Description |
 |------|-------------|
-|[getAlternatePatientID](#pidgetalternatepatientid)||
-|[getBirthOrder](#pidgetbirthorder)||
-|[getBirthPlace](#pidgetbirthplace)||
-|[getCitizenship](#pidgetcitizenship)||
-|[getCountryCode](#pidgetcountrycode)||
-|[getDateTimeOfBirth](#pidgetdatetimeofbirth)||
-|[getDriversLicenseNumber](#pidgetdriverslicensenumber)||
-|[getEthnicGroup](#pidgetethnicgroup)||
-|[getID](#pidgetid)||
-|[getMaritalStatus](#pidgetmaritalstatus)||
-|[getMothersIdentifier](#pidgetmothersidentifier)||
-|[getMothersMaidenName](#pidgetmothersmaidenname)||
-|[getMultipleBirthIndicator](#pidgetmultiplebirthindicator)||
-|[getNationality](#pidgetnationality)||
-|[getPatientAccountNumber](#pidgetpatientaccountnumber)||
-|[getPatientAddress](#pidgetpatientaddress)||
-|[getPatientAlias](#pidgetpatientalias)||
-|[getPatientDeathDateAndTime](#pidgetpatientdeathdateandtime)||
-|[getPatientDeathIndicator](#pidgetpatientdeathindicator)||
-|[getPatientID](#pidgetpatientid)||
-|[getPatientIdentifierList](#pidgetpatientidentifierlist)|Patient ID (Internal ID)|
-|[getPatientName](#pidgetpatientname)||
-|[getPhoneNumberBusiness](#pidgetphonenumberbusiness)||
-|[getPhoneNumberHome](#pidgetphonenumberhome)||
-|[getPrimaryLanguage](#pidgetprimarylanguage)||
-|[getRace](#pidgetrace)||
-|[getReligion](#pidgetreligion)||
-|[getSSNNumber](#pidgetssnnumber)||
-|[getSex](#pidgetsex)||
-|[getVeteransMilitaryStatus](#pidgetveteransmilitarystatus)||
-|[setAlternatePatientID](#pidsetalternatepatientid)||
-|[setBirthOrder](#pidsetbirthorder)||
-|[setBirthPlace](#pidsetbirthplace)||
-|[setCitizenship](#pidsetcitizenship)||
-|[setCountryCode](#pidsetcountrycode)||
-|[setDateTimeOfBirth](#pidsetdatetimeofbirth)||
-|[setDriversLicenseNumber](#pidsetdriverslicensenumber)||
-|[setEthnicGroup](#pidsetethnicgroup)||
+|[__destruct](#pid__destruct)||
+|[getAlternatePatientID](#pidgetalternatepatientid)|Get Alternate PatientID (OBR.4)|
+|[getBirthOrder](#pidgetbirthorder)|Get Birth Order (OBR.25)|
+|[getBirthPlace](#pidgetbirthplace)|Get Birth Place (OBR.23)|
+|[getCitizenship](#pidgetcitizenship)|Get Citizenship (OBR.26)|
+|[getCountryCode](#pidgetcountrycode)|Get Country Code (OBR.12)|
+|[getDateTimeOfBirth](#pidgetdatetimeofbirth)|Get Date TimeOfBirth (OBR.7)|
+|[getDriversLicenseNumber](#pidgetdriverslicensenumber)|Get Drivers LicenseNumber (OBR.20)|
+|[getEthnicGroup](#pidgetethnicgroup)|Get Ethnic Group (OBR.22)|
+|[getID](#pidgetid)|Get ID (OBR.1)|
+|[getMaritalStatus](#pidgetmaritalstatus)|Get Marital Status (OBR.16)|
+|[getMothersIdentifier](#pidgetmothersidentifier)|Get Mothers Identifier (OBR.21)|
+|[getMothersMaidenName](#pidgetmothersmaidenname)|Get Mothers MaidenName (OBR.6)|
+|[getMultipleBirthIndicator](#pidgetmultiplebirthindicator)|Get Multiple BirthIndicator (OBR.24)|
+|[getNationality](#pidgetnationality)|Get Nationality (OBR.28)|
+|[getPatientAccountNumber](#pidgetpatientaccountnumber)|Get Patient AccountNumber (OBR.18)|
+|[getPatientAddress](#pidgetpatientaddress)|Get Patient Address (OBR.11)|
+|[getPatientAlias](#pidgetpatientalias)|Get Patient Alias (OBR.9)|
+|[getPatientDeathDateAndTime](#pidgetpatientdeathdateandtime)|Get Patient DeathDateAndTime (OBR.29)|
+|[getPatientDeathIndicator](#pidgetpatientdeathindicator)|Get Patient DeathIndicator (OBR.30)|
+|[getPatientID](#pidgetpatientid)|Get Patient ID (OBR.2)|
+|[getPatientIdentifierList](#pidgetpatientidentifierlist)|Get Patient IdentifierList (OBR.3)|
+|[getPatientName](#pidgetpatientname)|Get Patient Name (OBR.5)|
+|[getPhoneNumberBusiness](#pidgetphonenumberbusiness)|Get Phone NumberBusiness (OBR.14)|
+|[getPhoneNumberHome](#pidgetphonenumberhome)|Get Phone NumberHome (OBR.13)|
+|[getPrimaryLanguage](#pidgetprimarylanguage)|Get Primary Language (OBR.15)|
+|[getRace](#pidgetrace)|Get Race (OBR.10)|
+|[getReligion](#pidgetreligion)|Get Religion (OBR.17)|
+|[getSSNNumber](#pidgetssnnumber)|Get SSNNumber (OBR.19)|
+|[getSex](#pidgetsex)|Get Sex (OBR.8)|
+|[getVeteransMilitaryStatus](#pidgetveteransmilitarystatus)|Get Veterans MilitaryStatus (OBR.27)|
+|[resetIndex](#pidresetindex)|Reset index of this segment|
+|[setAlternatePatientID](#pidsetalternatepatientid)|Set Alternate PatientID (OBR.4)|
+|[setBirthOrder](#pidsetbirthorder)|Set Birth Order (OBR.25)|
+|[setBirthPlace](#pidsetbirthplace)|Set Birth Place (OBR.23)|
+|[setCitizenship](#pidsetcitizenship)|Set Citizenship (OBR.26)|
+|[setCountryCode](#pidsetcountrycode)|Set Country Code (OBR.12)|
+|[setDateTimeOfBirth](#pidsetdatetimeofbirth)|Set Date TimeOfBirth (OBR.7)|
+|[setDriversLicenseNumber](#pidsetdriverslicensenumber)|Set Drivers LicenseNumber (OBR.20)|
+|[setEthnicGroup](#pidsetethnicgroup)|Set Ethnic Group (OBR.22)|
 |[setID](#pidsetid)||
-|[setMaritalStatus](#pidsetmaritalstatus)||
-|[setMothersIdentifier](#pidsetmothersidentifier)||
-|[setMothersMaidenName](#pidsetmothersmaidenname)||
-|[setMultipleBirthIndicator](#pidsetmultiplebirthindicator)||
-|[setNationality](#pidsetnationality)||
-|[setPatientAccountNumber](#pidsetpatientaccountnumber)||
-|[setPatientAddress](#pidsetpatientaddress)||
-|[setPatientAlias](#pidsetpatientalias)||
-|[setPatientDeathDateAndTime](#pidsetpatientdeathdateandtime)||
-|[setPatientDeathIndicator](#pidsetpatientdeathindicator)||
-|[setPatientID](#pidsetpatientid)||
-|[setPatientIdentifierList](#pidsetpatientidentifierlist)|Patient ID (Internal ID)|
-|[setPatientName](#pidsetpatientname)||
-|[setPhoneNumberBusiness](#pidsetphonenumberbusiness)||
-|[setPhoneNumberHome](#pidsetphonenumberhome)||
-|[setPrimaryLanguage](#pidsetprimarylanguage)||
-|[setRace](#pidsetrace)||
-|[setReligion](#pidsetreligion)||
-|[setSSNNumber](#pidsetssnnumber)||
+|[setMaritalStatus](#pidsetmaritalstatus)|Set Marital Status (OBR.16)|
+|[setMothersIdentifier](#pidsetmothersidentifier)|Set Mothers Identifier (OBR.21)|
+|[setMothersMaidenName](#pidsetmothersmaidenname)|Set Mothers MaidenName (OBR.6)|
+|[setMultipleBirthIndicator](#pidsetmultiplebirthindicator)|Set Multiple BirthIndicator (OBR.24)|
+|[setNationality](#pidsetnationality)|Set Nationality (OBR.28)|
+|[setPatientAccountNumber](#pidsetpatientaccountnumber)|Set Patient AccountNumber (OBR.18)|
+|[setPatientAddress](#pidsetpatientaddress)|Set Patient Address (OBR.11)|
+|[setPatientAlias](#pidsetpatientalias)|Set Patient Alias (OBR.9)|
+|[setPatientDeathDateAndTime](#pidsetpatientdeathdateandtime)|Set Patient DeathDateAndTime (OBR.29)|
+|[setPatientDeathIndicator](#pidsetpatientdeathindicator)|Set Patient DeathIndicator (OBR.30)|
+|[setPatientID](#pidsetpatientid)|Set Patient ID (OBR.2)|
+|[setPatientIdentifierList](#pidsetpatientidentifierlist)|Set Patient IdentifierList (OBR.3)|
+|[setPatientName](#pidsetpatientname)|Set Patient Name (OBR.5)|
+|[setPhoneNumberBusiness](#pidsetphonenumberbusiness)|Set Phone NumberBusiness (OBR.14)|
+|[setPhoneNumberHome](#pidsetphonenumberhome)|Set Phone NumberHome (OBR.13)|
+|[setPrimaryLanguage](#pidsetprimarylanguage)|Set Primary Language (OBR.15)|
+|[setRace](#pidsetrace)|Set Race (OBR.10)|
+|[setReligion](#pidsetreligion)|Set Religion (OBR.17)|
+|[setSSNNumber](#pidsetssnnumber)|Set SSNNumber (OBR.19)|
 |[setSex](#pidsetsex)||
-|[setVeteransMilitaryStatus](#pidsetveteransmilitarystatus)||
+|[setVeteransMilitaryStatus](#pidsetveteransmilitarystatus)|Set Veterans MilitaryStatus (OBR.27)|
 
 ## Inherited methods
 
 | Name | Description |
 |------|-------------|
 |__construct|Create a segment.|
+|clearField|Remove any existing value from the field|
 |getField|Get the field at index.|
 |getFields|Get fields from a segment|
 |getName|Get the name of the segment. This is basically the value at index 0|
@@ -86,12 +90,12 @@ Aranyasen\HL7\Segment
 
 
 
-### PID::getAlternatePatientID  
+### PID::__destruct  
 
 **Description**
 
 ```php
-public getAlternatePatientID (void)
+ __destruct (void)
 ```
 
  
@@ -105,6 +109,34 @@ public getAlternatePatientID (void)
 **Return Values**
 
 `void`
+
+
+<hr />
+
+
+### PID::getAlternatePatientID  
+
+**Description**
+
+```php
+public getAlternatePatientID (int $position)
+```
+
+Get Alternate PatientID (OBR.4) 
+
+ 
+
+**Parameters**
+
+* `(int) $position`
+: Defaults to 4  
+
+**Return Values**
+
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -114,20 +146,24 @@ public getAlternatePatientID (void)
 **Description**
 
 ```php
-public getBirthOrder (void)
+public getBirthOrder (int $position)
 ```
 
- 
+Get Birth Order (OBR.25) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 25  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -137,20 +173,24 @@ public getBirthOrder (void)
 **Description**
 
 ```php
-public getBirthPlace (void)
+public getBirthPlace (int $position)
 ```
 
- 
+Get Birth Place (OBR.23) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 23  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -160,20 +200,24 @@ public getBirthPlace (void)
 **Description**
 
 ```php
-public getCitizenship (void)
+public getCitizenship (int $position)
 ```
 
- 
+Get Citizenship (OBR.26) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 26  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -183,20 +227,24 @@ public getCitizenship (void)
 **Description**
 
 ```php
-public getCountryCode (void)
+public getCountryCode (int $position)
 ```
 
- 
+Get Country Code (OBR.12) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 12  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -206,20 +254,24 @@ public getCountryCode (void)
 **Description**
 
 ```php
-public getDateTimeOfBirth (void)
+public getDateTimeOfBirth (int $position)
 ```
 
- 
+Get Date TimeOfBirth (OBR.7) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 7  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -229,20 +281,24 @@ public getDateTimeOfBirth (void)
 **Description**
 
 ```php
-public getDriversLicenseNumber (void)
+public getDriversLicenseNumber (int $position)
 ```
 
- 
+Get Drivers LicenseNumber (OBR.20) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 20  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -252,20 +308,24 @@ public getDriversLicenseNumber (void)
 **Description**
 
 ```php
-public getEthnicGroup (void)
+public getEthnicGroup (int $position)
 ```
 
- 
+Get Ethnic Group (OBR.22) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 22  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -275,20 +335,24 @@ public getEthnicGroup (void)
 **Description**
 
 ```php
-public getID (void)
+public getID (int $position)
 ```
 
- 
+Get ID (OBR.1) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 1  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -298,20 +362,24 @@ public getID (void)
 **Description**
 
 ```php
-public getMaritalStatus (void)
+public getMaritalStatus (int $position)
 ```
 
- 
+Get Marital Status (OBR.16) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 16  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -321,20 +389,24 @@ public getMaritalStatus (void)
 **Description**
 
 ```php
-public getMothersIdentifier (void)
+public getMothersIdentifier (int $position)
 ```
 
- 
+Get Mothers Identifier (OBR.21) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 21  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -344,20 +416,24 @@ public getMothersIdentifier (void)
 **Description**
 
 ```php
-public getMothersMaidenName (void)
+public getMothersMaidenName (int $position)
 ```
 
- 
+Get Mothers MaidenName (OBR.6) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 6  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -367,20 +443,24 @@ public getMothersMaidenName (void)
 **Description**
 
 ```php
-public getMultipleBirthIndicator (void)
+public getMultipleBirthIndicator (int $position)
 ```
 
- 
+Get Multiple BirthIndicator (OBR.24) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 24  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -390,20 +470,24 @@ public getMultipleBirthIndicator (void)
 **Description**
 
 ```php
-public getNationality (void)
+public getNationality (int $position)
 ```
 
- 
+Get Nationality (OBR.28) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 28  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -413,20 +497,24 @@ public getNationality (void)
 **Description**
 
 ```php
-public getPatientAccountNumber (void)
+public getPatientAccountNumber (int $position)
 ```
 
- 
+Get Patient AccountNumber (OBR.18) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 18  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -436,20 +524,24 @@ public getPatientAccountNumber (void)
 **Description**
 
 ```php
-public getPatientAddress (void)
+public getPatientAddress (int $position)
 ```
 
- 
+Get Patient Address (OBR.11) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 11  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -459,20 +551,24 @@ public getPatientAddress (void)
 **Description**
 
 ```php
-public getPatientAlias (void)
+public getPatientAlias (int $position)
 ```
 
- 
+Get Patient Alias (OBR.9) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 9  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -482,20 +578,24 @@ public getPatientAlias (void)
 **Description**
 
 ```php
-public getPatientDeathDateAndTime (void)
+public getPatientDeathDateAndTime (int $position)
 ```
 
- 
+Get Patient DeathDateAndTime (OBR.29) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 29  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -505,20 +605,24 @@ public getPatientDeathDateAndTime (void)
 **Description**
 
 ```php
-public getPatientDeathIndicator (void)
+public getPatientDeathIndicator (int $position)
 ```
 
- 
+Get Patient DeathIndicator (OBR.30) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 30  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -528,20 +632,24 @@ public getPatientDeathIndicator (void)
 **Description**
 
 ```php
-public getPatientID (void)
+public getPatientID (int $position)
 ```
 
- 
+Get Patient ID (OBR.2) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 2  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -554,17 +662,19 @@ public getPatientID (void)
 public getPatientIdentifierList (int $position)
 ```
 
-Patient ID (Internal ID) 
+Get Patient IdentifierList (OBR.3) 
 
  
 
 **Parameters**
 
 * `(int) $position`
+: Defaults to 3  
 
 **Return Values**
 
-`array|null|string`
+`array|string|int|null`
+
 
 
 
@@ -576,20 +686,24 @@ Patient ID (Internal ID)
 **Description**
 
 ```php
-public getPatientName (void)
+public getPatientName (int $position)
 ```
 
- 
+Get Patient Name (OBR.5) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 5  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -599,20 +713,24 @@ public getPatientName (void)
 **Description**
 
 ```php
-public getPhoneNumberBusiness (void)
+public getPhoneNumberBusiness (int $position)
 ```
 
- 
+Get Phone NumberBusiness (OBR.14) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 14  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -622,20 +740,24 @@ public getPhoneNumberBusiness (void)
 **Description**
 
 ```php
-public getPhoneNumberHome (void)
+public getPhoneNumberHome (int $position)
 ```
 
- 
+Get Phone NumberHome (OBR.13) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 13  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -645,20 +767,24 @@ public getPhoneNumberHome (void)
 **Description**
 
 ```php
-public getPrimaryLanguage (void)
+public getPrimaryLanguage (int $position)
 ```
 
- 
+Get Primary Language (OBR.15) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 15  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -668,20 +794,24 @@ public getPrimaryLanguage (void)
 **Description**
 
 ```php
-public getRace (void)
+public getRace (int $position)
 ```
 
- 
+Get Race (OBR.10) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 10  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -691,20 +821,24 @@ public getRace (void)
 **Description**
 
 ```php
-public getReligion (void)
+public getReligion (int $position)
 ```
 
- 
+Get Religion (OBR.17) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 17  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -714,20 +848,24 @@ public getReligion (void)
 **Description**
 
 ```php
-public getSSNNumber (void)
+public getSSNNumber (int $position)
 ```
 
- 
+Get SSNNumber (OBR.19) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 19  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -737,20 +875,24 @@ public getSSNNumber (void)
 **Description**
 
 ```php
-public getSex (void)
+public getSex (int $position)
 ```
 
- 
+Get Sex (OBR.8) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 8  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -760,10 +902,37 @@ public getSex (void)
 **Description**
 
 ```php
-public getVeteransMilitaryStatus (void)
+public getVeteransMilitaryStatus (int $position)
 ```
 
+Get Veterans MilitaryStatus (OBR.27) 
+
  
+
+**Parameters**
+
+* `(int) $position`
+: Defaults to 27  
+
+**Return Values**
+
+`array|string|int|null`
+
+
+
+
+<hr />
+
+
+### PID::resetIndex  
+
+**Description**
+
+```php
+public static resetIndex (void)
+```
+
+Reset index of this segment 
 
  
 
@@ -774,6 +943,7 @@ public getVeteransMilitaryStatus (void)
 **Return Values**
 
 `void`
+
 
 <hr />
 
@@ -783,20 +953,25 @@ public getVeteransMilitaryStatus (void)
 **Description**
 
 ```php
-public setAlternatePatientID (void)
+public setAlternatePatientID (string|int|array|null $value, int $position)
 ```
 
- 
+Set Alternate PatientID (OBR.4) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 4  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -806,20 +981,25 @@ public setAlternatePatientID (void)
 **Description**
 
 ```php
-public setBirthOrder (void)
+public setBirthOrder (string|int|array|null $value, int $position)
 ```
 
- 
+Set Birth Order (OBR.25) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 25  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -829,20 +1009,25 @@ public setBirthOrder (void)
 **Description**
 
 ```php
-public setBirthPlace (void)
+public setBirthPlace (string|int|array|null $value, int $position)
 ```
 
- 
+Set Birth Place (OBR.23) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 23  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -852,20 +1037,25 @@ public setBirthPlace (void)
 **Description**
 
 ```php
-public setCitizenship (void)
+public setCitizenship (string|int|array|null $value, int $position)
 ```
 
- 
+Set Citizenship (OBR.26) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 26  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -875,20 +1065,25 @@ public setCitizenship (void)
 **Description**
 
 ```php
-public setCountryCode (void)
+public setCountryCode (string|int|array|null $value, int $position)
 ```
 
- 
+Set Country Code (OBR.12) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 12  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -898,20 +1093,25 @@ public setCountryCode (void)
 **Description**
 
 ```php
-public setDateTimeOfBirth (void)
+public setDateTimeOfBirth (string|int|array|null $value, int $position)
 ```
 
- 
+Set Date TimeOfBirth (OBR.7) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 7  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -921,20 +1121,25 @@ public setDateTimeOfBirth (void)
 **Description**
 
 ```php
-public setDriversLicenseNumber (void)
+public setDriversLicenseNumber (string|int|array|null $value, int $position)
 ```
 
- 
+Set Drivers LicenseNumber (OBR.20) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 20  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -944,20 +1149,25 @@ public setDriversLicenseNumber (void)
 **Description**
 
 ```php
-public setEthnicGroup (void)
+public setEthnicGroup (string|int|array|null $value, int $position)
 ```
 
- 
+Set Ethnic Group (OBR.22) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 22  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -967,7 +1177,7 @@ public setEthnicGroup (void)
 **Description**
 
 ```php
-public setID (void)
+ setID (void)
 ```
 
  
@@ -981,6 +1191,7 @@ public setID (void)
 **Return Values**
 
 `void`
+
 
 <hr />
 
@@ -990,20 +1201,25 @@ public setID (void)
 **Description**
 
 ```php
-public setMaritalStatus (void)
+public setMaritalStatus (string|int|array|null $value, int $position)
 ```
 
- 
+Set Marital Status (OBR.16) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 16  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1013,20 +1229,25 @@ public setMaritalStatus (void)
 **Description**
 
 ```php
-public setMothersIdentifier (void)
+public setMothersIdentifier (string|int|array|null $value, int $position)
 ```
 
- 
+Set Mothers Identifier (OBR.21) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 21  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1036,20 +1257,25 @@ public setMothersIdentifier (void)
 **Description**
 
 ```php
-public setMothersMaidenName (void)
+public setMothersMaidenName (string|int|array|null $value, int $position)
 ```
 
- 
+Set Mothers MaidenName (OBR.6) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 6  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1059,20 +1285,25 @@ public setMothersMaidenName (void)
 **Description**
 
 ```php
-public setMultipleBirthIndicator (void)
+public setMultipleBirthIndicator (string|int|array|null $value, int $position)
 ```
 
- 
+Set Multiple BirthIndicator (OBR.24) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 24  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1082,20 +1313,25 @@ public setMultipleBirthIndicator (void)
 **Description**
 
 ```php
-public setNationality (void)
+public setNationality (string|int|array|null $value, int $position)
 ```
 
- 
+Set Nationality (OBR.28) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 28  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1105,20 +1341,25 @@ public setNationality (void)
 **Description**
 
 ```php
-public setPatientAccountNumber (void)
+public setPatientAccountNumber (string|int|array|null $value, int $position)
 ```
 
- 
+Set Patient AccountNumber (OBR.18) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 18  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1128,20 +1369,25 @@ public setPatientAccountNumber (void)
 **Description**
 
 ```php
-public setPatientAddress (void)
+public setPatientAddress (string|int|array|null $value, int $position)
 ```
 
- 
+Set Patient Address (OBR.11) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 11  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1151,20 +1397,25 @@ public setPatientAddress (void)
 **Description**
 
 ```php
-public setPatientAlias (void)
+public setPatientAlias (string|int|array|null $value, int $position)
 ```
 
- 
+Set Patient Alias (OBR.9) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 9  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1174,20 +1425,25 @@ public setPatientAlias (void)
 **Description**
 
 ```php
-public setPatientDeathDateAndTime (void)
+public setPatientDeathDateAndTime (string|int|array|null $value, int $position)
 ```
 
- 
+Set Patient DeathDateAndTime (OBR.29) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 29  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1197,20 +1453,25 @@ public setPatientDeathDateAndTime (void)
 **Description**
 
 ```php
-public setPatientDeathIndicator (void)
+public setPatientDeathIndicator (string|int|array|null $value, int $position)
 ```
 
- 
+Set Patient DeathIndicator (OBR.30) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 30  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1220,20 +1481,25 @@ public setPatientDeathIndicator (void)
 **Description**
 
 ```php
-public setPatientID (void)
+public setPatientID (string|int|array|null $value, int $position)
 ```
 
- 
+Set Patient ID (OBR.2) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 2  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1243,21 +1509,23 @@ public setPatientID (void)
 **Description**
 
 ```php
-public setPatientIdentifierList (string $value, int $position)
+public setPatientIdentifierList (string|int|array|null $value, int $position)
 ```
 
-Patient ID (Internal ID) 
+Set Patient IdentifierList (OBR.3) 
 
  
 
 **Parameters**
 
-* `(string) $value`
+* `(string|int|array|null) $value`
 * `(int) $position`
+: Defaults to 3  
 
 **Return Values**
 
 `bool`
+
 
 
 
@@ -1269,20 +1537,25 @@ Patient ID (Internal ID)
 **Description**
 
 ```php
-public setPatientName (void)
+public setPatientName (string|int|array|null $value, int $position)
 ```
 
- 
+Set Patient Name (OBR.5) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 5  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1292,20 +1565,25 @@ public setPatientName (void)
 **Description**
 
 ```php
-public setPhoneNumberBusiness (void)
+public setPhoneNumberBusiness (string|int|array|null $value, int $position)
 ```
 
- 
+Set Phone NumberBusiness (OBR.14) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 14  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1315,20 +1593,25 @@ public setPhoneNumberBusiness (void)
 **Description**
 
 ```php
-public setPhoneNumberHome (void)
+public setPhoneNumberHome (string|int|array|null $value, int $position)
 ```
 
- 
+Set Phone NumberHome (OBR.13) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 13  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1338,20 +1621,25 @@ public setPhoneNumberHome (void)
 **Description**
 
 ```php
-public setPrimaryLanguage (void)
+public setPrimaryLanguage (string|int|array|null $value, int $position)
 ```
 
- 
+Set Primary Language (OBR.15) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 15  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1361,20 +1649,25 @@ public setPrimaryLanguage (void)
 **Description**
 
 ```php
-public setRace (void)
+public setRace (string|int|array|null $value, int $position)
 ```
 
- 
+Set Race (OBR.10) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 10  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1384,20 +1677,25 @@ public setRace (void)
 **Description**
 
 ```php
-public setReligion (void)
+public setReligion (string|int|array|null $value, int $position)
 ```
 
- 
+Set Religion (OBR.17) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 17  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1407,20 +1705,25 @@ public setReligion (void)
 **Description**
 
 ```php
-public setSSNNumber (void)
+public setSSNNumber (string|int|array|null $value, int $position)
 ```
 
- 
+Set SSNNumber (OBR.19) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 19  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1430,7 +1733,7 @@ public setSSNNumber (void)
 **Description**
 
 ```php
-public setSex (void)
+ setSex (void)
 ```
 
  
@@ -1444,6 +1747,7 @@ public setSex (void)
 **Return Values**
 
 `void`
+
 
 <hr />
 
@@ -1453,20 +1757,25 @@ public setSex (void)
 **Description**
 
 ```php
-public setVeteransMilitaryStatus (void)
+public setVeteransMilitaryStatus (string|int|array|null $value, int $position)
 ```
 
- 
+Set Veterans MilitaryStatus (OBR.27) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 27  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 

--- a/docs/Segments/PV1.md
+++ b/docs/Segments/PV1.md
@@ -13,116 +13,119 @@ Aranyasen\HL7\Segment
 
 | Name | Description |
 |------|-------------|
-|[getAccountStatus](#pv1getaccountstatus)||
-|[getAdmissionType](#pv1getadmissiontype)||
-|[getAdmitDateTime](#pv1getadmitdatetime)||
-|[getAdmitSource](#pv1getadmitsource)||
-|[getAdmittingDoctor](#pv1getadmittingdoctor)||
-|[getAlternateVisitID](#pv1getalternatevisitid)||
-|[getAmbulatoryStatus](#pv1getambulatorystatus)||
-|[getAssignedPatientLocation](#pv1getassignedpatientlocation)||
-|[getAttendingDoctor](#pv1getattendingdoctor)||
-|[getBadDebtAgencyCode](#pv1getbaddebtagencycode)||
-|[getBadDebtRecoveryAmount](#pv1getbaddebtrecoveryamount)||
-|[getBadDebtTransferAmount](#pv1getbaddebttransferamount)||
-|[getBedStatus](#pv1getbedstatus)||
-|[getChargePriceIndicator](#pv1getchargepriceindicator)||
-|[getConsultingDoctor](#pv1getconsultingdoctor)||
-|[getContractAmount](#pv1getcontractamount)||
-|[getContractCode](#pv1getcontractcode)||
-|[getContractEffectiveDate](#pv1getcontracteffectivedate)||
-|[getContractPeriod](#pv1getcontractperiod)||
-|[getCourtesyCode](#pv1getcourtesycode)||
-|[getCreditRating](#pv1getcreditrating)||
-|[getCurrentPatientBalance](#pv1getcurrentpatientbalance)||
-|[getDeleteAccountDate](#pv1getdeleteaccountdate)||
-|[getDeleteAccountIndicator](#pv1getdeleteaccountindicator)||
-|[getDietType](#pv1getdiettype)||
-|[getDischargeDateTime](#pv1getdischargedatetime)||
-|[getDischargeDisposition](#pv1getdischargedisposition)||
-|[getDischargedToLocation](#pv1getdischargedtolocation)||
-|[getFinancialClass](#pv1getfinancialclass)||
-|[getHospitalService](#pv1gethospitalservice)||
-|[getID](#pv1getid)||
-|[getInterestCode](#pv1getinterestcode)||
-|[getOtherHealthcareProvider](#pv1getotherhealthcareprovider)||
-|[getPatientClass](#pv1getpatientclass)||
-|[getPatientType](#pv1getpatienttype)||
-|[getPendingLocation](#pv1getpendinglocation)||
-|[getPreAdmitNumber](#pv1getpreadmitnumber)||
-|[getPreAdmitTestIndicator](#pv1getpreadmittestindicator)||
-|[getPriorPatientLocation](#pv1getpriorpatientlocation)||
-|[getPriorTemporaryLocation](#pv1getpriortemporarylocation)||
-|[getReAdmissionIndicator](#pv1getreadmissionindicator)||
-|[getReferringDoctor](#pv1getreferringdoctor)||
-|[getServicingFacility](#pv1getservicingfacility)||
-|[getTemporaryLocation](#pv1gettemporarylocation)||
-|[getTotalAdjustments](#pv1gettotaladjustments)||
-|[getTotalCharges](#pv1gettotalcharges)||
-|[getTotalPayments](#pv1gettotalpayments)||
-|[getTransferToBadDebtCode](#pv1gettransfertobaddebtcode)||
-|[getTransferToBadDebtDate](#pv1gettransfertobaddebtdate)||
-|[getVipIndicator](#pv1getvipindicator)||
-|[getVisitIndicator](#pv1getvisitindicator)||
-|[getVisitNumber](#pv1getvisitnumber)||
-|[setAccountStatus](#pv1setaccountstatus)||
-|[setAdmissionType](#pv1setadmissiontype)||
-|[setAdmitDateTime](#pv1setadmitdatetime)||
-|[setAdmitSource](#pv1setadmitsource)||
-|[setAdmittingDoctor](#pv1setadmittingdoctor)||
-|[setAlternateVisitID](#pv1setalternatevisitid)||
-|[setAmbulatoryStatus](#pv1setambulatorystatus)||
-|[setAssignedPatientLocation](#pv1setassignedpatientlocation)||
-|[setAttendingDoctor](#pv1setattendingdoctor)||
-|[setBadDebtAgencyCode](#pv1setbaddebtagencycode)||
-|[setBadDebtRecoveryAmount](#pv1setbaddebtrecoveryamount)||
-|[setBadDebtTransferAmount](#pv1setbaddebttransferamount)||
-|[setBedStatus](#pv1setbedstatus)||
-|[setChargePriceIndicator](#pv1setchargepriceindicator)||
-|[setConsultingDoctor](#pv1setconsultingdoctor)||
-|[setContractAmount](#pv1setcontractamount)||
-|[setContractCode](#pv1setcontractcode)||
-|[setContractEffectiveDate](#pv1setcontracteffectivedate)||
-|[setContractPeriod](#pv1setcontractperiod)||
-|[setCourtesyCode](#pv1setcourtesycode)||
-|[setCreditRating](#pv1setcreditrating)||
-|[setCurrentPatientBalance](#pv1setcurrentpatientbalance)||
-|[setDeleteAccountDate](#pv1setdeleteaccountdate)||
-|[setDeleteAccountIndicator](#pv1setdeleteaccountindicator)||
-|[setDietType](#pv1setdiettype)||
-|[setDischargeDateTime](#pv1setdischargedatetime)||
-|[setDischargeDisposition](#pv1setdischargedisposition)||
-|[setDischargedToLocation](#pv1setdischargedtolocation)||
-|[setFinancialClass](#pv1setfinancialclass)||
-|[setHospitalService](#pv1sethospitalservice)||
+|[__destruct](#pv1__destruct)||
+|[getAccountStatus](#pv1getaccountstatus)|Get Account Status (OBR.41)|
+|[getAdmissionType](#pv1getadmissiontype)|Get Admission Type (OBR.4)|
+|[getAdmitDateTime](#pv1getadmitdatetime)|Get Admit DateTime (OBR.44)|
+|[getAdmitSource](#pv1getadmitsource)|Get Admit Source (OBR.14)|
+|[getAdmittingDoctor](#pv1getadmittingdoctor)|Get Admitting Doctor (OBR.17)|
+|[getAlternateVisitID](#pv1getalternatevisitid)|Get Alternate VisitID (OBR.50)|
+|[getAmbulatoryStatus](#pv1getambulatorystatus)|Get Ambulatory Status (OBR.15)|
+|[getAssignedPatientLocation](#pv1getassignedpatientlocation)|Get Assigned PatientLocation (OBR.3)|
+|[getAttendingDoctor](#pv1getattendingdoctor)|Get Attending Doctor (OBR.7)|
+|[getBadDebtAgencyCode](#pv1getbaddebtagencycode)|Get Bad DebtAgencyCode (OBR.31)|
+|[getBadDebtRecoveryAmount](#pv1getbaddebtrecoveryamount)|Get Bad DebtRecoveryAmount (OBR.33)|
+|[getBadDebtTransferAmount](#pv1getbaddebttransferamount)|Get Bad DebtTransferAmount (OBR.32)|
+|[getBedStatus](#pv1getbedstatus)|Get Bed Status (OBR.40)|
+|[getChargePriceIndicator](#pv1getchargepriceindicator)|Get Charge PriceIndicator (OBR.21)|
+|[getConsultingDoctor](#pv1getconsultingdoctor)|Get Consulting Doctor (OBR.9)|
+|[getContractAmount](#pv1getcontractamount)|Get Contract Amount (OBR.26)|
+|[getContractCode](#pv1getcontractcode)|Get Contract Code (OBR.24)|
+|[getContractEffectiveDate](#pv1getcontracteffectivedate)|Get Contract EffectiveDate (OBR.25)|
+|[getContractPeriod](#pv1getcontractperiod)|Get Contract Period (OBR.27)|
+|[getCourtesyCode](#pv1getcourtesycode)|Get Courtesy Code (OBR.22)|
+|[getCreditRating](#pv1getcreditrating)|Get Credit Rating (OBR.23)|
+|[getCurrentPatientBalance](#pv1getcurrentpatientbalance)|Get Current PatientBalance (OBR.46)|
+|[getDeleteAccountDate](#pv1getdeleteaccountdate)|Get Delete AccountDate (OBR.35)|
+|[getDeleteAccountIndicator](#pv1getdeleteaccountindicator)|Get Delete AccountIndicator (OBR.34)|
+|[getDietType](#pv1getdiettype)|Get Diet Type (OBR.38)|
+|[getDischargeDateTime](#pv1getdischargedatetime)|Get Discharge DateTime (OBR.45)|
+|[getDischargeDisposition](#pv1getdischargedisposition)|Get Discharge Disposition (OBR.36)|
+|[getDischargedToLocation](#pv1getdischargedtolocation)|Get Discharged ToLocation (OBR.37)|
+|[getFinancialClass](#pv1getfinancialclass)|Get Financial Class (OBR.20)|
+|[getHospitalService](#pv1gethospitalservice)|Get Hospital Service (OBR.10)|
+|[getID](#pv1getid)|Get ID (OBR.1)|
+|[getInterestCode](#pv1getinterestcode)|Get Interest Code (OBR.28)|
+|[getOtherHealthcareProvider](#pv1getotherhealthcareprovider)|Get Other HealthcareProvider (OBR.52)|
+|[getPatientClass](#pv1getpatientclass)|Get Patient Class (OBR.2)|
+|[getPatientType](#pv1getpatienttype)|Get Patient Type (OBR.18)|
+|[getPendingLocation](#pv1getpendinglocation)|Get Pending Location (OBR.42)|
+|[getPreAdmitNumber](#pv1getpreadmitnumber)|Get Pre AdmitNumber (OBR.5)|
+|[getPreAdmitTestIndicator](#pv1getpreadmittestindicator)|Get Pre AdmitTestIndicator (OBR.12)|
+|[getPriorPatientLocation](#pv1getpriorpatientlocation)|Get Prior PatientLocation (OBR.6)|
+|[getPriorTemporaryLocation](#pv1getpriortemporarylocation)|Get Prior TemporaryLocation (OBR.43)|
+|[getReAdmissionIndicator](#pv1getreadmissionindicator)|Get Re AdmissionIndicator (OBR.13)|
+|[getReferringDoctor](#pv1getreferringdoctor)|Get Referring Doctor (OBR.8)|
+|[getServicingFacility](#pv1getservicingfacility)|Get Servicing Facility (OBR.39)|
+|[getTemporaryLocation](#pv1gettemporarylocation)|Get Temporary Location (OBR.11)|
+|[getTotalAdjustments](#pv1gettotaladjustments)|Get Total Adjustments (OBR.48)|
+|[getTotalCharges](#pv1gettotalcharges)|Get Total Charges (OBR.47)|
+|[getTotalPayments](#pv1gettotalpayments)|Get Total Payments (OBR.49)|
+|[getTransferToBadDebtCode](#pv1gettransfertobaddebtcode)|Get Transfer ToBadDebtCode (OBR.29)|
+|[getTransferToBadDebtDate](#pv1gettransfertobaddebtdate)|Get Transfer ToBadDebtDate (OBR.30)|
+|[getVipIndicator](#pv1getvipindicator)|Get Vip Indicator (OBR.16)|
+|[getVisitIndicator](#pv1getvisitindicator)|Get Visit Indicator (OBR.51)|
+|[getVisitNumber](#pv1getvisitnumber)|Get Visit Number (OBR.19)|
+|[resetIndex](#pv1resetindex)|Reset index of this segment|
+|[setAccountStatus](#pv1setaccountstatus)|Set Account Status (OBR.41)|
+|[setAdmissionType](#pv1setadmissiontype)|Set Admission Type (OBR.4)|
+|[setAdmitDateTime](#pv1setadmitdatetime)|Set Admit DateTime (OBR.44)|
+|[setAdmitSource](#pv1setadmitsource)|Set Admit Source (OBR.14)|
+|[setAdmittingDoctor](#pv1setadmittingdoctor)|Set Admitting Doctor (OBR.17)|
+|[setAlternateVisitID](#pv1setalternatevisitid)|Set Alternate VisitID (OBR.50)|
+|[setAmbulatoryStatus](#pv1setambulatorystatus)|Set Ambulatory Status (OBR.15)|
+|[setAssignedPatientLocation](#pv1setassignedpatientlocation)|Set Assigned PatientLocation (OBR.3)|
+|[setAttendingDoctor](#pv1setattendingdoctor)|Set Attending Doctor (OBR.7)|
+|[setBadDebtAgencyCode](#pv1setbaddebtagencycode)|Set Bad DebtAgencyCode (OBR.31)|
+|[setBadDebtRecoveryAmount](#pv1setbaddebtrecoveryamount)|Set Bad DebtRecoveryAmount (OBR.33)|
+|[setBadDebtTransferAmount](#pv1setbaddebttransferamount)|Set Bad DebtTransferAmount (OBR.32)|
+|[setBedStatus](#pv1setbedstatus)|Set Bed Status (OBR.40)|
+|[setChargePriceIndicator](#pv1setchargepriceindicator)|Set Charge PriceIndicator (OBR.21)|
+|[setConsultingDoctor](#pv1setconsultingdoctor)|Set Consulting Doctor (OBR.9)|
+|[setContractAmount](#pv1setcontractamount)|Set Contract Amount (OBR.26)|
+|[setContractCode](#pv1setcontractcode)|Set Contract Code (OBR.24)|
+|[setContractEffectiveDate](#pv1setcontracteffectivedate)|Set Contract EffectiveDate (OBR.25)|
+|[setContractPeriod](#pv1setcontractperiod)|Set Contract Period (OBR.27)|
+|[setCourtesyCode](#pv1setcourtesycode)|Set Courtesy Code (OBR.22)|
+|[setCreditRating](#pv1setcreditrating)|Set Credit Rating (OBR.23)|
+|[setCurrentPatientBalance](#pv1setcurrentpatientbalance)|Set Current PatientBalance (OBR.46)|
+|[setDeleteAccountDate](#pv1setdeleteaccountdate)|Set Delete AccountDate (OBR.35)|
+|[setDeleteAccountIndicator](#pv1setdeleteaccountindicator)|Set Delete AccountIndicator (OBR.34)|
+|[setDietType](#pv1setdiettype)|Set Diet Type (OBR.38)|
+|[setDischargeDateTime](#pv1setdischargedatetime)|Set Discharge DateTime (OBR.45)|
+|[setDischargeDisposition](#pv1setdischargedisposition)|Set Discharge Disposition (OBR.36)|
+|[setDischargedToLocation](#pv1setdischargedtolocation)|Set Discharged ToLocation (OBR.37)|
+|[setFinancialClass](#pv1setfinancialclass)|Set Financial Class (OBR.20)|
+|[setHospitalService](#pv1sethospitalservice)|Set Hospital Service (OBR.10)|
 |[setID](#pv1setid)||
-|[setInterestCode](#pv1setinterestcode)||
-|[setOtherHealthcareProvider](#pv1setotherhealthcareprovider)||
-|[setPatientClass](#pv1setpatientclass)||
-|[setPatientType](#pv1setpatienttype)||
-|[setPendingLocation](#pv1setpendinglocation)||
-|[setPreAdmitNumber](#pv1setpreadmitnumber)||
-|[setPreAdmitTestIndicator](#pv1setpreadmittestindicator)||
-|[setPriorPatientLocation](#pv1setpriorpatientlocation)||
-|[setPriorTemporaryLocation](#pv1setpriortemporarylocation)||
-|[setReAdmissionIndicator](#pv1setreadmissionindicator)||
-|[setReferringDoctor](#pv1setreferringdoctor)||
-|[setServicingFacility](#pv1setservicingfacility)||
-|[setTemporaryLocation](#pv1settemporarylocation)||
-|[setTotalAdjustments](#pv1settotaladjustments)||
-|[setTotalCharges](#pv1settotalcharges)||
-|[setTotalPayments](#pv1settotalpayments)||
-|[setTransferToBadDebtCode](#pv1settransfertobaddebtcode)||
-|[setTransferToBadDebtDate](#pv1settransfertobaddebtdate)||
-|[setVipIndicator](#pv1setvipindicator)||
-|[setVisitIndicator](#pv1setvisitindicator)||
-|[setVisitNumber](#pv1setvisitnumber)||
+|[setInterestCode](#pv1setinterestcode)|Set Interest Code (OBR.28)|
+|[setOtherHealthcareProvider](#pv1setotherhealthcareprovider)|Set Other HealthcareProvider (OBR.52)|
+|[setPatientClass](#pv1setpatientclass)|Set Patient Class (OBR.2)|
+|[setPatientType](#pv1setpatienttype)|Set Patient Type (OBR.18)|
+|[setPendingLocation](#pv1setpendinglocation)|Set Pending Location (OBR.42)|
+|[setPreAdmitNumber](#pv1setpreadmitnumber)|Set Pre AdmitNumber (OBR.5)|
+|[setPreAdmitTestIndicator](#pv1setpreadmittestindicator)|Set Pre AdmitTestIndicator (OBR.12)|
+|[setPriorPatientLocation](#pv1setpriorpatientlocation)|Set Prior PatientLocation (OBR.6)|
+|[setPriorTemporaryLocation](#pv1setpriortemporarylocation)|Set Prior TemporaryLocation (OBR.43)|
+|[setReAdmissionIndicator](#pv1setreadmissionindicator)|Set Re AdmissionIndicator (OBR.13)|
+|[setReferringDoctor](#pv1setreferringdoctor)|Set Referring Doctor (OBR.8)|
+|[setServicingFacility](#pv1setservicingfacility)|Set Servicing Facility (OBR.39)|
+|[setTemporaryLocation](#pv1settemporarylocation)|Set Temporary Location (OBR.11)|
+|[setTotalAdjustments](#pv1settotaladjustments)|Set Total Adjustments (OBR.48)|
+|[setTotalCharges](#pv1settotalcharges)|Set Total Charges (OBR.47)|
+|[setTotalPayments](#pv1settotalpayments)|Set Total Payments (OBR.49)|
+|[setTransferToBadDebtCode](#pv1settransfertobaddebtcode)|Set Transfer ToBadDebtCode (OBR.29)|
+|[setTransferToBadDebtDate](#pv1settransfertobaddebtdate)|Set Transfer ToBadDebtDate (OBR.30)|
+|[setVipIndicator](#pv1setvipindicator)|Set Vip Indicator (OBR.16)|
+|[setVisitIndicator](#pv1setvisitindicator)|Set Visit Indicator (OBR.51)|
+|[setVisitNumber](#pv1setvisitnumber)|Set Visit Number (OBR.19)|
 
 ## Inherited methods
 
 | Name | Description |
 |------|-------------|
 |__construct|Create a segment.|
+|clearField|Remove any existing value from the field|
 |getField|Get the field at index.|
 |getFields|Get fields from a segment|
 |getName|Get the name of the segment. This is basically the value at index 0|
@@ -131,12 +134,12 @@ Aranyasen\HL7\Segment
 
 
 
-### PV1::getAccountStatus  
+### PV1::__destruct  
 
 **Description**
 
 ```php
-public getAccountStatus (void)
+ __destruct (void)
 ```
 
  
@@ -150,6 +153,34 @@ public getAccountStatus (void)
 **Return Values**
 
 `void`
+
+
+<hr />
+
+
+### PV1::getAccountStatus  
+
+**Description**
+
+```php
+public getAccountStatus (int $position)
+```
+
+Get Account Status (OBR.41) 
+
+ 
+
+**Parameters**
+
+* `(int) $position`
+: Defaults to 41  
+
+**Return Values**
+
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -159,20 +190,24 @@ public getAccountStatus (void)
 **Description**
 
 ```php
-public getAdmissionType (void)
+public getAdmissionType (int $position)
 ```
 
- 
+Get Admission Type (OBR.4) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 4  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -182,20 +217,24 @@ public getAdmissionType (void)
 **Description**
 
 ```php
-public getAdmitDateTime (void)
+public getAdmitDateTime (int $position)
 ```
 
- 
+Get Admit DateTime (OBR.44) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 44  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -205,20 +244,24 @@ public getAdmitDateTime (void)
 **Description**
 
 ```php
-public getAdmitSource (void)
+public getAdmitSource (int $position)
 ```
 
- 
+Get Admit Source (OBR.14) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 14  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -228,20 +271,24 @@ public getAdmitSource (void)
 **Description**
 
 ```php
-public getAdmittingDoctor (void)
+public getAdmittingDoctor (int $position)
 ```
 
- 
+Get Admitting Doctor (OBR.17) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 17  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -251,20 +298,24 @@ public getAdmittingDoctor (void)
 **Description**
 
 ```php
-public getAlternateVisitID (void)
+public getAlternateVisitID (int $position)
 ```
 
- 
+Get Alternate VisitID (OBR.50) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 50  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -274,20 +325,24 @@ public getAlternateVisitID (void)
 **Description**
 
 ```php
-public getAmbulatoryStatus (void)
+public getAmbulatoryStatus (int $position)
 ```
 
- 
+Get Ambulatory Status (OBR.15) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 15  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -297,20 +352,24 @@ public getAmbulatoryStatus (void)
 **Description**
 
 ```php
-public getAssignedPatientLocation (void)
+public getAssignedPatientLocation (int $position)
 ```
 
- 
+Get Assigned PatientLocation (OBR.3) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 3  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -320,20 +379,24 @@ public getAssignedPatientLocation (void)
 **Description**
 
 ```php
-public getAttendingDoctor (void)
+public getAttendingDoctor (int $position)
 ```
 
- 
+Get Attending Doctor (OBR.7) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 7  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -343,20 +406,24 @@ public getAttendingDoctor (void)
 **Description**
 
 ```php
-public getBadDebtAgencyCode (void)
+public getBadDebtAgencyCode (int $position)
 ```
 
- 
+Get Bad DebtAgencyCode (OBR.31) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 31  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -366,20 +433,24 @@ public getBadDebtAgencyCode (void)
 **Description**
 
 ```php
-public getBadDebtRecoveryAmount (void)
+public getBadDebtRecoveryAmount (int $position)
 ```
 
- 
+Get Bad DebtRecoveryAmount (OBR.33) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 33  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -389,20 +460,24 @@ public getBadDebtRecoveryAmount (void)
 **Description**
 
 ```php
-public getBadDebtTransferAmount (void)
+public getBadDebtTransferAmount (int $position)
 ```
 
- 
+Get Bad DebtTransferAmount (OBR.32) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 32  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -412,20 +487,24 @@ public getBadDebtTransferAmount (void)
 **Description**
 
 ```php
-public getBedStatus (void)
+public getBedStatus (int $position)
 ```
 
- 
+Get Bed Status (OBR.40) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 40  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -435,20 +514,24 @@ public getBedStatus (void)
 **Description**
 
 ```php
-public getChargePriceIndicator (void)
+public getChargePriceIndicator (int $position)
 ```
 
- 
+Get Charge PriceIndicator (OBR.21) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 21  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -458,20 +541,24 @@ public getChargePriceIndicator (void)
 **Description**
 
 ```php
-public getConsultingDoctor (void)
+public getConsultingDoctor (int $position)
 ```
 
- 
+Get Consulting Doctor (OBR.9) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 9  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -481,20 +568,24 @@ public getConsultingDoctor (void)
 **Description**
 
 ```php
-public getContractAmount (void)
+public getContractAmount (int $position)
 ```
 
- 
+Get Contract Amount (OBR.26) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 26  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -504,20 +595,24 @@ public getContractAmount (void)
 **Description**
 
 ```php
-public getContractCode (void)
+public getContractCode (int $position)
 ```
 
- 
+Get Contract Code (OBR.24) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 24  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -527,20 +622,24 @@ public getContractCode (void)
 **Description**
 
 ```php
-public getContractEffectiveDate (void)
+public getContractEffectiveDate (int $position)
 ```
 
- 
+Get Contract EffectiveDate (OBR.25) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 25  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -550,20 +649,24 @@ public getContractEffectiveDate (void)
 **Description**
 
 ```php
-public getContractPeriod (void)
+public getContractPeriod (int $position)
 ```
 
- 
+Get Contract Period (OBR.27) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 27  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -573,20 +676,24 @@ public getContractPeriod (void)
 **Description**
 
 ```php
-public getCourtesyCode (void)
+public getCourtesyCode (int $position)
 ```
 
- 
+Get Courtesy Code (OBR.22) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 22  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -596,20 +703,24 @@ public getCourtesyCode (void)
 **Description**
 
 ```php
-public getCreditRating (void)
+public getCreditRating (int $position)
 ```
 
- 
+Get Credit Rating (OBR.23) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 23  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -619,20 +730,24 @@ public getCreditRating (void)
 **Description**
 
 ```php
-public getCurrentPatientBalance (void)
+public getCurrentPatientBalance (int $position)
 ```
 
- 
+Get Current PatientBalance (OBR.46) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 46  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -642,20 +757,24 @@ public getCurrentPatientBalance (void)
 **Description**
 
 ```php
-public getDeleteAccountDate (void)
+public getDeleteAccountDate (int $position)
 ```
 
- 
+Get Delete AccountDate (OBR.35) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 35  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -665,20 +784,24 @@ public getDeleteAccountDate (void)
 **Description**
 
 ```php
-public getDeleteAccountIndicator (void)
+public getDeleteAccountIndicator (int $position)
 ```
 
- 
+Get Delete AccountIndicator (OBR.34) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 34  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -688,20 +811,24 @@ public getDeleteAccountIndicator (void)
 **Description**
 
 ```php
-public getDietType (void)
+public getDietType (int $position)
 ```
 
- 
+Get Diet Type (OBR.38) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 38  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -711,20 +838,24 @@ public getDietType (void)
 **Description**
 
 ```php
-public getDischargeDateTime (void)
+public getDischargeDateTime (int $position)
 ```
 
- 
+Get Discharge DateTime (OBR.45) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 45  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -734,20 +865,24 @@ public getDischargeDateTime (void)
 **Description**
 
 ```php
-public getDischargeDisposition (void)
+public getDischargeDisposition (int $position)
 ```
 
- 
+Get Discharge Disposition (OBR.36) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 36  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -757,20 +892,24 @@ public getDischargeDisposition (void)
 **Description**
 
 ```php
-public getDischargedToLocation (void)
+public getDischargedToLocation (int $position)
 ```
 
- 
+Get Discharged ToLocation (OBR.37) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 37  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -780,20 +919,24 @@ public getDischargedToLocation (void)
 **Description**
 
 ```php
-public getFinancialClass (void)
+public getFinancialClass (int $position)
 ```
 
- 
+Get Financial Class (OBR.20) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 20  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -803,20 +946,24 @@ public getFinancialClass (void)
 **Description**
 
 ```php
-public getHospitalService (void)
+public getHospitalService (int $position)
 ```
 
- 
+Get Hospital Service (OBR.10) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 10  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -826,20 +973,24 @@ public getHospitalService (void)
 **Description**
 
 ```php
-public getID (void)
+public getID (int $position)
 ```
 
- 
+Get ID (OBR.1) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 1  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -849,20 +1000,24 @@ public getID (void)
 **Description**
 
 ```php
-public getInterestCode (void)
+public getInterestCode (int $position)
 ```
 
- 
+Get Interest Code (OBR.28) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 28  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -872,20 +1027,24 @@ public getInterestCode (void)
 **Description**
 
 ```php
-public getOtherHealthcareProvider (void)
+public getOtherHealthcareProvider (int $position)
 ```
 
- 
+Get Other HealthcareProvider (OBR.52) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 52  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -895,20 +1054,24 @@ public getOtherHealthcareProvider (void)
 **Description**
 
 ```php
-public getPatientClass (void)
+public getPatientClass (int $position)
 ```
 
- 
+Get Patient Class (OBR.2) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 2  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -918,20 +1081,24 @@ public getPatientClass (void)
 **Description**
 
 ```php
-public getPatientType (void)
+public getPatientType (int $position)
 ```
 
- 
+Get Patient Type (OBR.18) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 18  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -941,20 +1108,24 @@ public getPatientType (void)
 **Description**
 
 ```php
-public getPendingLocation (void)
+public getPendingLocation (int $position)
 ```
 
- 
+Get Pending Location (OBR.42) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 42  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -964,20 +1135,24 @@ public getPendingLocation (void)
 **Description**
 
 ```php
-public getPreAdmitNumber (void)
+public getPreAdmitNumber (int $position)
 ```
 
- 
+Get Pre AdmitNumber (OBR.5) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 5  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -987,20 +1162,24 @@ public getPreAdmitNumber (void)
 **Description**
 
 ```php
-public getPreAdmitTestIndicator (void)
+public getPreAdmitTestIndicator (int $position)
 ```
 
- 
+Get Pre AdmitTestIndicator (OBR.12) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 12  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -1010,20 +1189,24 @@ public getPreAdmitTestIndicator (void)
 **Description**
 
 ```php
-public getPriorPatientLocation (void)
+public getPriorPatientLocation (int $position)
 ```
 
- 
+Get Prior PatientLocation (OBR.6) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 6  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -1033,20 +1216,24 @@ public getPriorPatientLocation (void)
 **Description**
 
 ```php
-public getPriorTemporaryLocation (void)
+public getPriorTemporaryLocation (int $position)
 ```
 
- 
+Get Prior TemporaryLocation (OBR.43) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 43  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -1056,20 +1243,24 @@ public getPriorTemporaryLocation (void)
 **Description**
 
 ```php
-public getReAdmissionIndicator (void)
+public getReAdmissionIndicator (int $position)
 ```
 
- 
+Get Re AdmissionIndicator (OBR.13) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 13  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -1079,20 +1270,24 @@ public getReAdmissionIndicator (void)
 **Description**
 
 ```php
-public getReferringDoctor (void)
+public getReferringDoctor (int $position)
 ```
 
- 
+Get Referring Doctor (OBR.8) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 8  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -1102,20 +1297,24 @@ public getReferringDoctor (void)
 **Description**
 
 ```php
-public getServicingFacility (void)
+public getServicingFacility (int $position)
 ```
 
- 
+Get Servicing Facility (OBR.39) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 39  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -1125,20 +1324,24 @@ public getServicingFacility (void)
 **Description**
 
 ```php
-public getTemporaryLocation (void)
+public getTemporaryLocation (int $position)
 ```
 
- 
+Get Temporary Location (OBR.11) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 11  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -1148,20 +1351,24 @@ public getTemporaryLocation (void)
 **Description**
 
 ```php
-public getTotalAdjustments (void)
+public getTotalAdjustments (int $position)
 ```
 
- 
+Get Total Adjustments (OBR.48) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 48  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -1171,20 +1378,24 @@ public getTotalAdjustments (void)
 **Description**
 
 ```php
-public getTotalCharges (void)
+public getTotalCharges (int $position)
 ```
 
- 
+Get Total Charges (OBR.47) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 47  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -1194,20 +1405,24 @@ public getTotalCharges (void)
 **Description**
 
 ```php
-public getTotalPayments (void)
+public getTotalPayments (int $position)
 ```
 
- 
+Get Total Payments (OBR.49) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 49  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -1217,20 +1432,24 @@ public getTotalPayments (void)
 **Description**
 
 ```php
-public getTransferToBadDebtCode (void)
+public getTransferToBadDebtCode (int $position)
 ```
 
- 
+Get Transfer ToBadDebtCode (OBR.29) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 29  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -1240,20 +1459,24 @@ public getTransferToBadDebtCode (void)
 **Description**
 
 ```php
-public getTransferToBadDebtDate (void)
+public getTransferToBadDebtDate (int $position)
 ```
 
- 
+Get Transfer ToBadDebtDate (OBR.30) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 30  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -1263,20 +1486,24 @@ public getTransferToBadDebtDate (void)
 **Description**
 
 ```php
-public getVipIndicator (void)
+public getVipIndicator (int $position)
 ```
 
- 
+Get Vip Indicator (OBR.16) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 16  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -1286,20 +1513,24 @@ public getVipIndicator (void)
 **Description**
 
 ```php
-public getVisitIndicator (void)
+public getVisitIndicator (int $position)
 ```
 
- 
+Get Visit Indicator (OBR.51) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 51  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
+
 
 <hr />
 
@@ -1309,10 +1540,37 @@ public getVisitIndicator (void)
 **Description**
 
 ```php
-public getVisitNumber (void)
+public getVisitNumber (int $position)
 ```
 
+Get Visit Number (OBR.19) 
+
  
+
+**Parameters**
+
+* `(int) $position`
+: Defaults to 19  
+
+**Return Values**
+
+`array|string|int|null`
+
+
+
+
+<hr />
+
+
+### PV1::resetIndex  
+
+**Description**
+
+```php
+public static resetIndex (void)
+```
+
+Reset index of this segment 
 
  
 
@@ -1324,6 +1582,7 @@ public getVisitNumber (void)
 
 `void`
 
+
 <hr />
 
 
@@ -1332,21 +1591,23 @@ public getVisitNumber (void)
 **Description**
 
 ```php
-public setAccountStatus ( $value, int $position)
+public setAccountStatus (string|int|array|null $value, int $position)
 ```
 
- 
+Set Account Status (OBR.41) 
 
  
 
 **Parameters**
 
-* `() $value`
+* `(string|int|array|null) $value`
 * `(int) $position`
+: Defaults to 41  
 
 **Return Values**
 
 `bool`
+
 
 
 
@@ -1358,21 +1619,23 @@ public setAccountStatus ( $value, int $position)
 **Description**
 
 ```php
-public setAdmissionType ( $value, int $position)
+public setAdmissionType (string|int|array|null $value, int $position)
 ```
 
- 
+Set Admission Type (OBR.4) 
 
  
 
 **Parameters**
 
-* `() $value`
+* `(string|int|array|null) $value`
 * `(int) $position`
+: Defaults to 4  
 
 **Return Values**
 
 `bool`
+
 
 
 
@@ -1384,21 +1647,23 @@ public setAdmissionType ( $value, int $position)
 **Description**
 
 ```php
-public setAdmitDateTime ( $value, int $position)
+public setAdmitDateTime (string|int|array|null $value, int $position)
 ```
 
- 
+Set Admit DateTime (OBR.44) 
 
  
 
 **Parameters**
 
-* `() $value`
+* `(string|int|array|null) $value`
 * `(int) $position`
+: Defaults to 44  
 
 **Return Values**
 
 `bool`
+
 
 
 
@@ -1410,21 +1675,23 @@ public setAdmitDateTime ( $value, int $position)
 **Description**
 
 ```php
-public setAdmitSource ( $value, int $position)
+public setAdmitSource (string|int|array|null $value, int $position)
 ```
 
- 
+Set Admit Source (OBR.14) 
 
  
 
 **Parameters**
 
-* `() $value`
+* `(string|int|array|null) $value`
 * `(int) $position`
+: Defaults to 14  
 
 **Return Values**
 
 `bool`
+
 
 
 
@@ -1436,21 +1703,23 @@ public setAdmitSource ( $value, int $position)
 **Description**
 
 ```php
-public setAdmittingDoctor ( $value, int $position)
+public setAdmittingDoctor (string|int|array|null $value, int $position)
 ```
 
- 
+Set Admitting Doctor (OBR.17) 
 
  
 
 **Parameters**
 
-* `() $value`
+* `(string|int|array|null) $value`
 * `(int) $position`
+: Defaults to 17  
 
 **Return Values**
 
 `bool`
+
 
 
 
@@ -1462,21 +1731,23 @@ public setAdmittingDoctor ( $value, int $position)
 **Description**
 
 ```php
-public setAlternateVisitID ( $value, int $position)
+public setAlternateVisitID (string|int|array|null $value, int $position)
 ```
 
- 
+Set Alternate VisitID (OBR.50) 
 
  
 
 **Parameters**
 
-* `() $value`
+* `(string|int|array|null) $value`
 * `(int) $position`
+: Defaults to 50  
 
 **Return Values**
 
 `bool`
+
 
 
 
@@ -1488,21 +1759,23 @@ public setAlternateVisitID ( $value, int $position)
 **Description**
 
 ```php
-public setAmbulatoryStatus ( $value, int $position)
+public setAmbulatoryStatus (string|int|array|null $value, int $position)
 ```
 
- 
+Set Ambulatory Status (OBR.15) 
 
  
 
 **Parameters**
 
-* `() $value`
+* `(string|int|array|null) $value`
 * `(int) $position`
+: Defaults to 15  
 
 **Return Values**
 
 `bool`
+
 
 
 
@@ -1514,20 +1787,25 @@ public setAmbulatoryStatus ( $value, int $position)
 **Description**
 
 ```php
-public setAssignedPatientLocation (void)
+public setAssignedPatientLocation (string|int|array|null $value, int $position)
 ```
 
- 
+Set Assigned PatientLocation (OBR.3) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 3  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -1537,21 +1815,23 @@ public setAssignedPatientLocation (void)
 **Description**
 
 ```php
-public setAttendingDoctor ( $value, int $position)
+public setAttendingDoctor (string|int|array|null $value, int $position)
 ```
 
- 
+Set Attending Doctor (OBR.7) 
 
  
 
 **Parameters**
 
-* `() $value`
+* `(string|int|array|null) $value`
 * `(int) $position`
+: Defaults to 7  
 
 **Return Values**
 
 `bool`
+
 
 
 
@@ -1563,21 +1843,23 @@ public setAttendingDoctor ( $value, int $position)
 **Description**
 
 ```php
-public setBadDebtAgencyCode ( $value, int $position)
+public setBadDebtAgencyCode (string|int|array|null $value, int $position)
 ```
 
- 
+Set Bad DebtAgencyCode (OBR.31) 
 
  
 
 **Parameters**
 
-* `() $value`
+* `(string|int|array|null) $value`
 * `(int) $position`
+: Defaults to 31  
 
 **Return Values**
 
 `bool`
+
 
 
 
@@ -1589,21 +1871,23 @@ public setBadDebtAgencyCode ( $value, int $position)
 **Description**
 
 ```php
-public setBadDebtRecoveryAmount ( $value, int $position)
+public setBadDebtRecoveryAmount (string|int|array|null $value, int $position)
 ```
 
- 
+Set Bad DebtRecoveryAmount (OBR.33) 
 
  
 
 **Parameters**
 
-* `() $value`
+* `(string|int|array|null) $value`
 * `(int) $position`
+: Defaults to 33  
 
 **Return Values**
 
 `bool`
+
 
 
 
@@ -1615,21 +1899,23 @@ public setBadDebtRecoveryAmount ( $value, int $position)
 **Description**
 
 ```php
-public setBadDebtTransferAmount ( $value, int $position)
+public setBadDebtTransferAmount (string|int|array|null $value, int $position)
 ```
 
- 
+Set Bad DebtTransferAmount (OBR.32) 
 
  
 
 **Parameters**
 
-* `() $value`
+* `(string|int|array|null) $value`
 * `(int) $position`
+: Defaults to 32  
 
 **Return Values**
 
 `bool`
+
 
 
 
@@ -1641,21 +1927,23 @@ public setBadDebtTransferAmount ( $value, int $position)
 **Description**
 
 ```php
-public setBedStatus ( $value, int $position)
+public setBedStatus (string|int|array|null $value, int $position)
 ```
 
- 
+Set Bed Status (OBR.40) 
 
  
 
 **Parameters**
 
-* `() $value`
+* `(string|int|array|null) $value`
 * `(int) $position`
+: Defaults to 40  
 
 **Return Values**
 
 `bool`
+
 
 
 
@@ -1667,21 +1955,23 @@ public setBedStatus ( $value, int $position)
 **Description**
 
 ```php
-public setChargePriceIndicator ( $value, int $position)
+public setChargePriceIndicator (string|int|array|null $value, int $position)
 ```
 
- 
+Set Charge PriceIndicator (OBR.21) 
 
  
 
 **Parameters**
 
-* `() $value`
+* `(string|int|array|null) $value`
 * `(int) $position`
+: Defaults to 21  
 
 **Return Values**
 
 `bool`
+
 
 
 
@@ -1693,21 +1983,23 @@ public setChargePriceIndicator ( $value, int $position)
 **Description**
 
 ```php
-public setConsultingDoctor ( $value, int $position)
+public setConsultingDoctor (string|int|array|null $value, int $position)
 ```
 
- 
+Set Consulting Doctor (OBR.9) 
 
  
 
 **Parameters**
 
-* `() $value`
+* `(string|int|array|null) $value`
 * `(int) $position`
+: Defaults to 9  
 
 **Return Values**
 
 `bool`
+
 
 
 
@@ -1719,21 +2011,23 @@ public setConsultingDoctor ( $value, int $position)
 **Description**
 
 ```php
-public setContractAmount ( $value, int $position)
+public setContractAmount (string|int|array|null $value, int $position)
 ```
 
- 
+Set Contract Amount (OBR.26) 
 
  
 
 **Parameters**
 
-* `() $value`
+* `(string|int|array|null) $value`
 * `(int) $position`
+: Defaults to 26  
 
 **Return Values**
 
 `bool`
+
 
 
 
@@ -1745,21 +2039,23 @@ public setContractAmount ( $value, int $position)
 **Description**
 
 ```php
-public setContractCode ( $value, int $position)
+public setContractCode (string|int|array|null $value, int $position)
 ```
 
- 
+Set Contract Code (OBR.24) 
 
  
 
 **Parameters**
 
-* `() $value`
+* `(string|int|array|null) $value`
 * `(int) $position`
+: Defaults to 24  
 
 **Return Values**
 
 `bool`
+
 
 
 
@@ -1771,21 +2067,23 @@ public setContractCode ( $value, int $position)
 **Description**
 
 ```php
-public setContractEffectiveDate ( $value, int $position)
+public setContractEffectiveDate (string|int|array|null $value, int $position)
 ```
 
- 
+Set Contract EffectiveDate (OBR.25) 
 
  
 
 **Parameters**
 
-* `() $value`
+* `(string|int|array|null) $value`
 * `(int) $position`
+: Defaults to 25  
 
 **Return Values**
 
 `bool`
+
 
 
 
@@ -1797,21 +2095,23 @@ public setContractEffectiveDate ( $value, int $position)
 **Description**
 
 ```php
-public setContractPeriod ( $value, int $position)
+public setContractPeriod (string|int|array|null $value, int $position)
 ```
 
- 
+Set Contract Period (OBR.27) 
 
  
 
 **Parameters**
 
-* `() $value`
+* `(string|int|array|null) $value`
 * `(int) $position`
+: Defaults to 27  
 
 **Return Values**
 
 `bool`
+
 
 
 
@@ -1823,21 +2123,23 @@ public setContractPeriod ( $value, int $position)
 **Description**
 
 ```php
-public setCourtesyCode ( $value, int $position)
+public setCourtesyCode (string|int|array|null $value, int $position)
 ```
 
- 
+Set Courtesy Code (OBR.22) 
 
  
 
 **Parameters**
 
-* `() $value`
+* `(string|int|array|null) $value`
 * `(int) $position`
+: Defaults to 22  
 
 **Return Values**
 
 `bool`
+
 
 
 
@@ -1849,21 +2151,23 @@ public setCourtesyCode ( $value, int $position)
 **Description**
 
 ```php
-public setCreditRating ( $value, int $position)
+public setCreditRating (string|int|array|null $value, int $position)
 ```
 
- 
+Set Credit Rating (OBR.23) 
 
  
 
 **Parameters**
 
-* `() $value`
+* `(string|int|array|null) $value`
 * `(int) $position`
+: Defaults to 23  
 
 **Return Values**
 
 `bool`
+
 
 
 
@@ -1875,21 +2179,23 @@ public setCreditRating ( $value, int $position)
 **Description**
 
 ```php
-public setCurrentPatientBalance ( $value, int $position)
+public setCurrentPatientBalance (string|int|array|null $value, int $position)
 ```
 
- 
+Set Current PatientBalance (OBR.46) 
 
  
 
 **Parameters**
 
-* `() $value`
+* `(string|int|array|null) $value`
 * `(int) $position`
+: Defaults to 46  
 
 **Return Values**
 
 `bool`
+
 
 
 
@@ -1901,21 +2207,23 @@ public setCurrentPatientBalance ( $value, int $position)
 **Description**
 
 ```php
-public setDeleteAccountDate ( $value, int $position)
+public setDeleteAccountDate (string|int|array|null $value, int $position)
 ```
 
- 
+Set Delete AccountDate (OBR.35) 
 
  
 
 **Parameters**
 
-* `() $value`
+* `(string|int|array|null) $value`
 * `(int) $position`
+: Defaults to 35  
 
 **Return Values**
 
 `bool`
+
 
 
 
@@ -1927,21 +2235,23 @@ public setDeleteAccountDate ( $value, int $position)
 **Description**
 
 ```php
-public setDeleteAccountIndicator ( $value, int $position)
+public setDeleteAccountIndicator (string|int|array|null $value, int $position)
 ```
 
- 
+Set Delete AccountIndicator (OBR.34) 
 
  
 
 **Parameters**
 
-* `() $value`
+* `(string|int|array|null) $value`
 * `(int) $position`
+: Defaults to 34  
 
 **Return Values**
 
 `bool`
+
 
 
 
@@ -1953,21 +2263,23 @@ public setDeleteAccountIndicator ( $value, int $position)
 **Description**
 
 ```php
-public setDietType ( $value, int $position)
+public setDietType (string|int|array|null $value, int $position)
 ```
 
- 
+Set Diet Type (OBR.38) 
 
  
 
 **Parameters**
 
-* `() $value`
+* `(string|int|array|null) $value`
 * `(int) $position`
+: Defaults to 38  
 
 **Return Values**
 
 `bool`
+
 
 
 
@@ -1979,21 +2291,23 @@ public setDietType ( $value, int $position)
 **Description**
 
 ```php
-public setDischargeDateTime ( $value, int $position)
+public setDischargeDateTime (string|int|array|null $value, int $position)
 ```
 
- 
+Set Discharge DateTime (OBR.45) 
 
  
 
 **Parameters**
 
-* `() $value`
+* `(string|int|array|null) $value`
 * `(int) $position`
+: Defaults to 45  
 
 **Return Values**
 
 `bool`
+
 
 
 
@@ -2005,21 +2319,23 @@ public setDischargeDateTime ( $value, int $position)
 **Description**
 
 ```php
-public setDischargeDisposition ( $value, int $position)
+public setDischargeDisposition (string|int|array|null $value, int $position)
 ```
 
- 
+Set Discharge Disposition (OBR.36) 
 
  
 
 **Parameters**
 
-* `() $value`
+* `(string|int|array|null) $value`
 * `(int) $position`
+: Defaults to 36  
 
 **Return Values**
 
 `bool`
+
 
 
 
@@ -2031,21 +2347,23 @@ public setDischargeDisposition ( $value, int $position)
 **Description**
 
 ```php
-public setDischargedToLocation ( $value, int $position)
+public setDischargedToLocation (string|int|array|null $value, int $position)
 ```
 
- 
+Set Discharged ToLocation (OBR.37) 
 
  
 
 **Parameters**
 
-* `() $value`
+* `(string|int|array|null) $value`
 * `(int) $position`
+: Defaults to 37  
 
 **Return Values**
 
 `bool`
+
 
 
 
@@ -2057,21 +2375,23 @@ public setDischargedToLocation ( $value, int $position)
 **Description**
 
 ```php
-public setFinancialClass ( $value, int $position)
+public setFinancialClass (string|int|array|null $value, int $position)
 ```
 
- 
+Set Financial Class (OBR.20) 
 
  
 
 **Parameters**
 
-* `() $value`
+* `(string|int|array|null) $value`
 * `(int) $position`
+: Defaults to 20  
 
 **Return Values**
 
 `bool`
+
 
 
 
@@ -2083,21 +2403,23 @@ public setFinancialClass ( $value, int $position)
 **Description**
 
 ```php
-public setHospitalService ( $value, int $position)
+public setHospitalService (string|int|array|null $value, int $position)
 ```
 
- 
+Set Hospital Service (OBR.10) 
 
  
 
 **Parameters**
 
-* `() $value`
+* `(string|int|array|null) $value`
 * `(int) $position`
+: Defaults to 10  
 
 **Return Values**
 
 `bool`
+
 
 
 
@@ -2109,7 +2431,7 @@ public setHospitalService ( $value, int $position)
 **Description**
 
 ```php
-public setID (void)
+ setID (void)
 ```
 
  
@@ -2124,6 +2446,7 @@ public setID (void)
 
 `void`
 
+
 <hr />
 
 
@@ -2132,21 +2455,23 @@ public setID (void)
 **Description**
 
 ```php
-public setInterestCode ( $value, int $position)
+public setInterestCode (string|int|array|null $value, int $position)
 ```
 
- 
+Set Interest Code (OBR.28) 
 
  
 
 **Parameters**
 
-* `() $value`
+* `(string|int|array|null) $value`
 * `(int) $position`
+: Defaults to 28  
 
 **Return Values**
 
 `bool`
+
 
 
 
@@ -2158,21 +2483,23 @@ public setInterestCode ( $value, int $position)
 **Description**
 
 ```php
-public setOtherHealthcareProvider ( $value, int $position)
+public setOtherHealthcareProvider (string|int|array|null $value, int $position)
 ```
 
- 
+Set Other HealthcareProvider (OBR.52) 
 
  
 
 **Parameters**
 
-* `() $value`
+* `(string|int|array|null) $value`
 * `(int) $position`
+: Defaults to 52  
 
 **Return Values**
 
 `bool`
+
 
 
 
@@ -2184,20 +2511,25 @@ public setOtherHealthcareProvider ( $value, int $position)
 **Description**
 
 ```php
-public setPatientClass (void)
+public setPatientClass (string|int|array|null $value, int $position)
 ```
 
- 
+Set Patient Class (OBR.2) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 2  
 
 **Return Values**
 
-`void`
+`bool`
+
+
+
 
 <hr />
 
@@ -2207,21 +2539,23 @@ public setPatientClass (void)
 **Description**
 
 ```php
-public setPatientType ( $value, int $position)
+public setPatientType (string|int|array|null $value, int $position)
 ```
 
- 
+Set Patient Type (OBR.18) 
 
  
 
 **Parameters**
 
-* `() $value`
+* `(string|int|array|null) $value`
 * `(int) $position`
+: Defaults to 18  
 
 **Return Values**
 
 `bool`
+
 
 
 
@@ -2233,21 +2567,23 @@ public setPatientType ( $value, int $position)
 **Description**
 
 ```php
-public setPendingLocation ( $value, int $position)
+public setPendingLocation (string|int|array|null $value, int $position)
 ```
 
- 
+Set Pending Location (OBR.42) 
 
  
 
 **Parameters**
 
-* `() $value`
+* `(string|int|array|null) $value`
 * `(int) $position`
+: Defaults to 42  
 
 **Return Values**
 
 `bool`
+
 
 
 
@@ -2259,21 +2595,23 @@ public setPendingLocation ( $value, int $position)
 **Description**
 
 ```php
-public setPreAdmitNumber ( $value, int $position)
+public setPreAdmitNumber (string|int|array|null $value, int $position)
 ```
 
- 
+Set Pre AdmitNumber (OBR.5) 
 
  
 
 **Parameters**
 
-* `() $value`
+* `(string|int|array|null) $value`
 * `(int) $position`
+: Defaults to 5  
 
 **Return Values**
 
 `bool`
+
 
 
 
@@ -2285,21 +2623,23 @@ public setPreAdmitNumber ( $value, int $position)
 **Description**
 
 ```php
-public setPreAdmitTestIndicator ( $value, int $position)
+public setPreAdmitTestIndicator (string|int|array|null $value, int $position)
 ```
 
- 
+Set Pre AdmitTestIndicator (OBR.12) 
 
  
 
 **Parameters**
 
-* `() $value`
+* `(string|int|array|null) $value`
 * `(int) $position`
+: Defaults to 12  
 
 **Return Values**
 
 `bool`
+
 
 
 
@@ -2311,21 +2651,23 @@ public setPreAdmitTestIndicator ( $value, int $position)
 **Description**
 
 ```php
-public setPriorPatientLocation ( $value, int $position)
+public setPriorPatientLocation (string|int|array|null $value, int $position)
 ```
 
- 
+Set Prior PatientLocation (OBR.6) 
 
  
 
 **Parameters**
 
-* `() $value`
+* `(string|int|array|null) $value`
 * `(int) $position`
+: Defaults to 6  
 
 **Return Values**
 
 `bool`
+
 
 
 
@@ -2337,21 +2679,23 @@ public setPriorPatientLocation ( $value, int $position)
 **Description**
 
 ```php
-public setPriorTemporaryLocation ( $value, int $position)
+public setPriorTemporaryLocation (string|int|array|null $value, int $position)
 ```
 
- 
+Set Prior TemporaryLocation (OBR.43) 
 
  
 
 **Parameters**
 
-* `() $value`
+* `(string|int|array|null) $value`
 * `(int) $position`
+: Defaults to 43  
 
 **Return Values**
 
 `bool`
+
 
 
 
@@ -2363,21 +2707,23 @@ public setPriorTemporaryLocation ( $value, int $position)
 **Description**
 
 ```php
-public setReAdmissionIndicator ( $value, int $position)
+public setReAdmissionIndicator (string|int|array|null $value, int $position)
 ```
 
- 
+Set Re AdmissionIndicator (OBR.13) 
 
  
 
 **Parameters**
 
-* `() $value`
+* `(string|int|array|null) $value`
 * `(int) $position`
+: Defaults to 13  
 
 **Return Values**
 
 `bool`
+
 
 
 
@@ -2389,21 +2735,23 @@ public setReAdmissionIndicator ( $value, int $position)
 **Description**
 
 ```php
-public setReferringDoctor ( $value, int $position)
+public setReferringDoctor (string|int|array|null $value, int $position)
 ```
 
- 
+Set Referring Doctor (OBR.8) 
 
  
 
 **Parameters**
 
-* `() $value`
+* `(string|int|array|null) $value`
 * `(int) $position`
+: Defaults to 8  
 
 **Return Values**
 
 `bool`
+
 
 
 
@@ -2415,21 +2763,23 @@ public setReferringDoctor ( $value, int $position)
 **Description**
 
 ```php
-public setServicingFacility ( $value, int $position)
+public setServicingFacility (string|int|array|null $value, int $position)
 ```
 
- 
+Set Servicing Facility (OBR.39) 
 
  
 
 **Parameters**
 
-* `() $value`
+* `(string|int|array|null) $value`
 * `(int) $position`
+: Defaults to 39  
 
 **Return Values**
 
 `bool`
+
 
 
 
@@ -2441,21 +2791,23 @@ public setServicingFacility ( $value, int $position)
 **Description**
 
 ```php
-public setTemporaryLocation ( $value, int $position)
+public setTemporaryLocation (string|int|array|null $value, int $position)
 ```
 
- 
+Set Temporary Location (OBR.11) 
 
  
 
 **Parameters**
 
-* `() $value`
+* `(string|int|array|null) $value`
 * `(int) $position`
+: Defaults to 11  
 
 **Return Values**
 
 `bool`
+
 
 
 
@@ -2467,21 +2819,23 @@ public setTemporaryLocation ( $value, int $position)
 **Description**
 
 ```php
-public setTotalAdjustments ( $value, int $position)
+public setTotalAdjustments (string|int|array|null $value, int $position)
 ```
 
- 
+Set Total Adjustments (OBR.48) 
 
  
 
 **Parameters**
 
-* `() $value`
+* `(string|int|array|null) $value`
 * `(int) $position`
+: Defaults to 48  
 
 **Return Values**
 
 `bool`
+
 
 
 
@@ -2493,21 +2847,23 @@ public setTotalAdjustments ( $value, int $position)
 **Description**
 
 ```php
-public setTotalCharges ( $value, int $position)
+public setTotalCharges (string|int|array|null $value, int $position)
 ```
 
- 
+Set Total Charges (OBR.47) 
 
  
 
 **Parameters**
 
-* `() $value`
+* `(string|int|array|null) $value`
 * `(int) $position`
+: Defaults to 47  
 
 **Return Values**
 
 `bool`
+
 
 
 
@@ -2519,21 +2875,23 @@ public setTotalCharges ( $value, int $position)
 **Description**
 
 ```php
-public setTotalPayments ( $value, int $position)
+public setTotalPayments (string|int|array|null $value, int $position)
 ```
 
- 
+Set Total Payments (OBR.49) 
 
  
 
 **Parameters**
 
-* `() $value`
+* `(string|int|array|null) $value`
 * `(int) $position`
+: Defaults to 49  
 
 **Return Values**
 
 `bool`
+
 
 
 
@@ -2545,21 +2903,23 @@ public setTotalPayments ( $value, int $position)
 **Description**
 
 ```php
-public setTransferToBadDebtCode ( $value, int $position)
+public setTransferToBadDebtCode (string|int|array|null $value, int $position)
 ```
 
- 
+Set Transfer ToBadDebtCode (OBR.29) 
 
  
 
 **Parameters**
 
-* `() $value`
+* `(string|int|array|null) $value`
 * `(int) $position`
+: Defaults to 29  
 
 **Return Values**
 
 `bool`
+
 
 
 
@@ -2571,21 +2931,23 @@ public setTransferToBadDebtCode ( $value, int $position)
 **Description**
 
 ```php
-public setTransferToBadDebtDate ( $value, int $position)
+public setTransferToBadDebtDate (string|int|array|null $value, int $position)
 ```
 
- 
+Set Transfer ToBadDebtDate (OBR.30) 
 
  
 
 **Parameters**
 
-* `() $value`
+* `(string|int|array|null) $value`
 * `(int) $position`
+: Defaults to 30  
 
 **Return Values**
 
 `bool`
+
 
 
 
@@ -2597,21 +2959,23 @@ public setTransferToBadDebtDate ( $value, int $position)
 **Description**
 
 ```php
-public setVipIndicator ( $value, int $position)
+public setVipIndicator (string|int|array|null $value, int $position)
 ```
 
- 
+Set Vip Indicator (OBR.16) 
 
  
 
 **Parameters**
 
-* `() $value`
+* `(string|int|array|null) $value`
 * `(int) $position`
+: Defaults to 16  
 
 **Return Values**
 
 `bool`
+
 
 
 
@@ -2623,21 +2987,23 @@ public setVipIndicator ( $value, int $position)
 **Description**
 
 ```php
-public setVisitIndicator ( $value, int $position)
+public setVisitIndicator (string|int|array|null $value, int $position)
 ```
 
- 
+Set Visit Indicator (OBR.51) 
 
  
 
 **Parameters**
 
-* `() $value`
+* `(string|int|array|null) $value`
 * `(int) $position`
+: Defaults to 51  
 
 **Return Values**
 
 `bool`
+
 
 
 
@@ -2649,21 +3015,23 @@ public setVisitIndicator ( $value, int $position)
 **Description**
 
 ```php
-public setVisitNumber ( $value, int $position)
+public setVisitNumber (string|int|array|null $value, int $position)
 ```
 
- 
+Set Visit Number (OBR.19) 
 
  
 
 **Parameters**
 
-* `() $value`
+* `(string|int|array|null) $value`
 * `(int) $position`
+: Defaults to 19  
 
 **Return Values**
 
 `bool`
+
 
 
 

--- a/docs/Segments/SAC.md
+++ b/docs/Segments/SAC.md
@@ -13,101 +13,102 @@ Aranyasen\HL7\Segment
 
 | Name | Description |
 |------|-------------|
-|[getAccessionIdentifier](#sacgetaccessionidentifier)||
-|[getAdditive](#sacgetadditive)||
-|[getArtificialBlood](#sacgetartificialblood)||
-|[getAvailableSpecimenVolume](#sacgetavailablespecimenvolume)||
-|[getBarrierDelta](#sacgetbarrierdelta)||
-|[getBottomDelta](#sacgetbottomdelta)||
-|[getCapType](#sacgetcaptype)||
-|[getCarrierIdentifier](#sacgetcarrieridentifier)||
-|[getCarrierType](#sacgetcarriertype)||
-|[getContainerDiameter](#sacgetcontainerdiameter)||
-|[getContainerHeight](#sacgetcontainerheight)||
-|[getContainerIdentifier](#sacgetcontaineridentifier)||
-|[getContainerSizeUnits](#sacgetcontainersizeunits)||
-|[getContainerStatus](#sacgetcontainerstatus)||
-|[getContainerVolume](#sacgetcontainervolume)||
-|[getDilutionFactor](#sacgetdilutionfactor)||
-|[getDrugInterference](#sacgetdruginterference)||
-|[getEquipmentContainerIdentifier](#sacgetequipmentcontaineridentifier)||
-|[getExternalAccessionIdentifier](#sacgetexternalaccessionidentifier)||
-|[getFibrinIndex](#sacgetfibrinindex)||
-|[getFibrinIndexUnits](#sacgetfibrinindexunits)||
-|[getHemolysisIndex](#sacgethemolysisindex)||
-|[getHemolysisIndexUnits](#sacgethemolysisindexunits)||
-|[getIcterusIndex](#sacgeticterusindex)||
-|[getIcterusIndexUnits](#sacgeticterusindexunits)||
-|[getInitialSpecimenVolume](#sacgetinitialspecimenvolume)||
-|[getLepemiaIndex](#sacgetlepemiaindex)||
-|[getLepemiaIndexUnits](#sacgetlepemiaindexunits)||
-|[getLocation](#sacgetlocation)||
-|[getOtherEnvironmentalFactors](#sacgetotherenvironmentalfactors)||
-|[getPositionInCarrier](#sacgetpositionincarrier)||
-|[getPositionInTray](#sacgetpositionintray)||
-|[getPrimaryContainerIdentifier](#sacgetprimarycontaineridentifier)||
-|[getRegistrationDateTime](#sacgetregistrationdatetime)||
-|[getSeparatorType](#sacgetseparatortype)||
-|[getSpecialHandlingCode](#sacgetspecialhandlingcode)||
-|[getSpecimenComponent](#sacgetspecimencomponent)||
-|[getSpecimenSource](#sacgetspecimensource)||
-|[getSystemInducedContaminants](#sacgetsysteminducedcontaminants)||
-|[getTemperature](#sacgettemperature)||
-|[getTrayIdentifier](#sacgettrayidentifier)||
-|[getTrayTypeSAC](#sacgettraytypesac)||
-|[getTreatment](#sacgettreatment)||
-|[getVolumeUnits](#sacgetvolumeunits)||
+|[getAccessionIdentifier](#sacgetaccessionidentifier)|Get Accession Identifier (OBR.2)|
+|[getAdditive](#sacgetadditive)|Get Additive (OBR.27)|
+|[getArtificialBlood](#sacgetartificialblood)|Get Artificial Blood (OBR.42)|
+|[getAvailableSpecimenVolume](#sacgetavailablespecimenvolume)|Get Available SpecimenVolume (OBR.22)|
+|[getBarrierDelta](#sacgetbarrierdelta)|Get Barrier Delta (OBR.18)|
+|[getBottomDelta](#sacgetbottomdelta)|Get Bottom Delta (OBR.19)|
+|[getCapType](#sacgetcaptype)|Get Cap Type (OBR.26)|
+|[getCarrierIdentifier](#sacgetcarrieridentifier)|Get Carrier Identifier (OBR.10)|
+|[getCarrierType](#sacgetcarriertype)|Get Carrier Type (OBR.9)|
+|[getContainerDiameter](#sacgetcontainerdiameter)|Get Container Diameter (OBR.17)|
+|[getContainerHeight](#sacgetcontainerheight)|Get Container Height (OBR.16)|
+|[getContainerIdentifier](#sacgetcontaineridentifier)|Get Container Identifier (OBR.3)|
+|[getContainerSizeUnits](#sacgetcontainersizeunits)|Get Container SizeUnits (OBR.20)|
+|[getContainerStatus](#sacgetcontainerstatus)|Get Container Status (OBR.8)|
+|[getContainerVolume](#sacgetcontainervolume)|Get Container Volume (OBR.21)|
+|[getDilutionFactor](#sacgetdilutionfactor)|Get Dilution Factor (OBR.29)|
+|[getDrugInterference](#sacgetdruginterference)|Get Drug Interference (OBR.41)|
+|[getEquipmentContainerIdentifier](#sacgetequipmentcontaineridentifier)|Get Equipment ContainerIdentifier (OBR.5)|
+|[getExternalAccessionIdentifier](#sacgetexternalaccessionidentifier)|Get External AccessionIdentifier (OBR.1)|
+|[getFibrinIndex](#sacgetfibrinindex)|Get Fibrin Index (OBR.38)|
+|[getFibrinIndexUnits](#sacgetfibrinindexunits)|Get Fibrin IndexUnits (OBR.39)|
+|[getHemolysisIndex](#sacgethemolysisindex)|Get Hemolysis Index (OBR.32)|
+|[getHemolysisIndexUnits](#sacgethemolysisindexunits)|Get Hemolysis IndexUnits (OBR.33)|
+|[getIcterusIndex](#sacgeticterusindex)|Get Icterus Index (OBR.36)|
+|[getIcterusIndexUnits](#sacgeticterusindexunits)|Get Icterus IndexUnits (OBR.37)|
+|[getInitialSpecimenVolume](#sacgetinitialspecimenvolume)|Get Initial SpecimenVolume (OBR.23)|
+|[getLepemiaIndex](#sacgetlepemiaindex)|Get Lepemia Index (OBR.34)|
+|[getLepemiaIndexUnits](#sacgetlepemiaindexunits)|Get Lepemia IndexUnits (OBR.35)|
+|[getLocation](#sacgetlocation)|Get Location (OBR.15)|
+|[getOtherEnvironmentalFactors](#sacgetotherenvironmentalfactors)|Get Other EnvironmentalFactors (OBR.44)|
+|[getPositionInCarrier](#sacgetpositionincarrier)|Get Position InCarrier (OBR.11)|
+|[getPositionInTray](#sacgetpositionintray)|Get Position InTray (OBR.14)|
+|[getPrimaryContainerIdentifier](#sacgetprimarycontaineridentifier)|Get Primary ContainerIdentifier (OBR.4)|
+|[getRegistrationDateTime](#sacgetregistrationdatetime)|Get Registration DateTime (OBR.7)|
+|[getSeparatorType](#sacgetseparatortype)|Get Separator Type (OBR.25)|
+|[getSpecialHandlingCode](#sacgetspecialhandlingcode)|Get Special HandlingCode (OBR.43)|
+|[getSpecimenComponent](#sacgetspecimencomponent)|Get Specimen Component (OBR.28)|
+|[getSpecimenSource](#sacgetspecimensource)|Get Specimen Source (OBR.6)|
+|[getSystemInducedContaminants](#sacgetsysteminducedcontaminants)|Get System InducedContaminants (OBR.40)|
+|[getTemperature](#sacgettemperature)|Get Temperature (OBR.31)|
+|[getTrayIdentifier](#sacgettrayidentifier)|Get Tray Identifier (OBR.13)|
+|[getTrayTypeSAC](#sacgettraytypesac)|Get Tray TypeSAC (OBR.12)|
+|[getTreatment](#sacgettreatment)|Get Treatment (OBR.30)|
+|[getVolumeUnits](#sacgetvolumeunits)|Get Volume Units (OBR.24)|
 |[resetIndex](#sacresetindex)|Reset index of this segment|
-|[setAccessionIdentifier](#sacsetaccessionidentifier)||
-|[setAdditive](#sacsetadditive)||
-|[setArtificialBlood](#sacsetartificialblood)||
-|[setAvailableSpecimenVolume](#sacsetavailablespecimenvolume)||
-|[setBarrierDelta](#sacsetbarrierdelta)||
-|[setBottomDelta](#sacsetbottomdelta)||
-|[setCapType](#sacsetcaptype)||
-|[setCarrierIdentifier](#sacsetcarrieridentifier)||
-|[setCarrierType](#sacsetcarriertype)||
-|[setContainerDiameter](#sacsetcontainerdiameter)||
-|[setContainerHeight](#sacsetcontainerheight)||
-|[setContainerIdentifier](#sacsetcontaineridentifier)||
-|[setContainerSizeUnits](#sacsetcontainersizeunits)||
-|[setContainerStatus](#sacsetcontainerstatus)||
-|[setContainerVolume](#sacsetcontainervolume)||
-|[setDilutionFactor](#sacsetdilutionfactor)||
-|[setDrugInterference](#sacsetdruginterference)||
-|[setEquipmentContainerIdentifier](#sacsetequipmentcontaineridentifier)||
+|[setAccessionIdentifier](#sacsetaccessionidentifier)|Set Accession Identifier (OBR.2)|
+|[setAdditive](#sacsetadditive)|Set Additive (OBR.27)|
+|[setArtificialBlood](#sacsetartificialblood)|Set Artificial Blood (OBR.42)|
+|[setAvailableSpecimenVolume](#sacsetavailablespecimenvolume)|Set Available SpecimenVolume (OBR.22)|
+|[setBarrierDelta](#sacsetbarrierdelta)|Set Barrier Delta (OBR.18)|
+|[setBottomDelta](#sacsetbottomdelta)|Set Bottom Delta (OBR.19)|
+|[setCapType](#sacsetcaptype)|Set Cap Type (OBR.26)|
+|[setCarrierIdentifier](#sacsetcarrieridentifier)|Set Carrier Identifier (OBR.10)|
+|[setCarrierType](#sacsetcarriertype)|Set Carrier Type (OBR.9)|
+|[setContainerDiameter](#sacsetcontainerdiameter)|Set Container Diameter (OBR.17)|
+|[setContainerHeight](#sacsetcontainerheight)|Set Container Height (OBR.16)|
+|[setContainerIdentifier](#sacsetcontaineridentifier)|Set Container Identifier (OBR.3)|
+|[setContainerSizeUnits](#sacsetcontainersizeunits)|Set Container SizeUnits (OBR.20)|
+|[setContainerStatus](#sacsetcontainerstatus)|Set Container Status (OBR.8)|
+|[setContainerVolume](#sacsetcontainervolume)|Set Container Volume (OBR.21)|
+|[setDilutionFactor](#sacsetdilutionfactor)|Set Dilution Factor (OBR.29)|
+|[setDrugInterference](#sacsetdruginterference)|Set Drug Interference (OBR.41)|
+|[setEquipmentContainerIdentifier](#sacsetequipmentcontaineridentifier)|Set Equipment ContainerIdentifier (OBR.5)|
 |[setExternalAccessionIdentifier](#sacsetexternalaccessionidentifier)||
-|[setFibrinIndex](#sacsetfibrinindex)||
-|[setFibrinIndexUnits](#sacsetfibrinindexunits)||
-|[setHemolysisIndex](#sacsethemolysisindex)||
-|[setHemolysisIndexUnits](#sacsethemolysisindexunits)||
-|[setIcterusIndex](#sacseticterusindex)||
-|[setIcterusIndexUnits](#sacseticterusindexunits)||
-|[setInitialSpecimenVolume](#sacsetinitialspecimenvolume)||
-|[setLepemiaIndex](#sacsetlepemiaindex)||
-|[setLepemiaIndexUnits](#sacsetlepemiaindexunits)||
-|[setLocation](#sacsetlocation)||
-|[setOtherEnvironmentalFactors](#sacsetotherenvironmentalfactors)||
-|[setPositionInCarrier](#sacsetpositionincarrier)||
-|[setPositionInTray](#sacsetpositionintray)||
-|[setPrimaryContainerIdentifier](#sacsetprimarycontaineridentifier)||
-|[setRegistrationDateTime](#sacsetregistrationdatetime)||
-|[setSeparatorType](#sacsetseparatortype)||
-|[setSpecialHandlingCode](#sacsetspecialhandlingcode)||
-|[setSpecimenComponent](#sacsetspecimencomponent)||
-|[setSpecimenSource](#sacsetspecimensource)||
-|[setSystemInducedContaminants](#sacsetsysteminducedcontaminants)||
-|[setTemperature](#sacsettemperature)||
-|[setTrayIdentifier](#sacsettrayidentifier)||
-|[setTrayTypeSAC](#sacsettraytypesac)||
-|[setTreatment](#sacsettreatment)||
-|[setVolumeUnits](#sacsetvolumeunits)||
+|[setFibrinIndex](#sacsetfibrinindex)|Set Fibrin Index (OBR.38)|
+|[setFibrinIndexUnits](#sacsetfibrinindexunits)|Set Fibrin IndexUnits (OBR.39)|
+|[setHemolysisIndex](#sacsethemolysisindex)|Set Hemolysis Index (OBR.32)|
+|[setHemolysisIndexUnits](#sacsethemolysisindexunits)|Set Hemolysis IndexUnits (OBR.33)|
+|[setIcterusIndex](#sacseticterusindex)|Set Icterus Index (OBR.36)|
+|[setIcterusIndexUnits](#sacseticterusindexunits)|Set Icterus IndexUnits (OBR.37)|
+|[setInitialSpecimenVolume](#sacsetinitialspecimenvolume)|Set Initial SpecimenVolume (OBR.23)|
+|[setLepemiaIndex](#sacsetlepemiaindex)|Set Lepemia Index (OBR.34)|
+|[setLepemiaIndexUnits](#sacsetlepemiaindexunits)|Set Lepemia IndexUnits (OBR.35)|
+|[setLocation](#sacsetlocation)|Set Location (OBR.15)|
+|[setOtherEnvironmentalFactors](#sacsetotherenvironmentalfactors)|Set Other EnvironmentalFactors (OBR.44)|
+|[setPositionInCarrier](#sacsetpositionincarrier)|Set Position InCarrier (OBR.11)|
+|[setPositionInTray](#sacsetpositionintray)|Set Position InTray (OBR.14)|
+|[setPrimaryContainerIdentifier](#sacsetprimarycontaineridentifier)|Set Primary ContainerIdentifier (OBR.4)|
+|[setRegistrationDateTime](#sacsetregistrationdatetime)|Set Registration DateTime (OBR.7)|
+|[setSeparatorType](#sacsetseparatortype)|Set Separator Type (OBR.25)|
+|[setSpecialHandlingCode](#sacsetspecialhandlingcode)|Set Special HandlingCode (OBR.43)|
+|[setSpecimenComponent](#sacsetspecimencomponent)|Set Specimen Component (OBR.28)|
+|[setSpecimenSource](#sacsetspecimensource)|Set Specimen Source (OBR.6)|
+|[setSystemInducedContaminants](#sacsetsysteminducedcontaminants)|Set System InducedContaminants (OBR.40)|
+|[setTemperature](#sacsettemperature)|Set Temperature (OBR.31)|
+|[setTrayIdentifier](#sacsettrayidentifier)|Set Tray Identifier (OBR.13)|
+|[setTrayTypeSAC](#sacsettraytypesac)|Set Tray TypeSAC (OBR.12)|
+|[setTreatment](#sacsettreatment)|Set Treatment (OBR.30)|
+|[setVolumeUnits](#sacsetvolumeunits)|Set Volume Units (OBR.24)|
 
 ## Inherited methods
 
 | Name | Description |
 |------|-------------|
 |__construct|Create a segment.|
+|clearField|Remove any existing value from the field|
 |getField|Get the field at index.|
 |getFields|Get fields from a segment|
 |getName|Get the name of the segment. This is basically the value at index 0|
@@ -121,20 +122,23 @@ Aranyasen\HL7\Segment
 **Description**
 
 ```php
- getAccessionIdentifier (void)
+public getAccessionIdentifier (int $position)
 ```
 
- 
+Get Accession Identifier (OBR.2) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 2  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
 
 
 <hr />
@@ -145,20 +149,23 @@ Aranyasen\HL7\Segment
 **Description**
 
 ```php
- getAdditive (void)
+public getAdditive (int $position)
 ```
 
- 
+Get Additive (OBR.27) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 27  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
 
 
 <hr />
@@ -169,20 +176,23 @@ Aranyasen\HL7\Segment
 **Description**
 
 ```php
- getArtificialBlood (void)
+public getArtificialBlood (int $position)
 ```
 
- 
+Get Artificial Blood (OBR.42) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 42  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
 
 
 <hr />
@@ -193,20 +203,23 @@ Aranyasen\HL7\Segment
 **Description**
 
 ```php
- getAvailableSpecimenVolume (void)
+public getAvailableSpecimenVolume (int $position)
 ```
 
- 
+Get Available SpecimenVolume (OBR.22) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 22  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
 
 
 <hr />
@@ -217,20 +230,23 @@ Aranyasen\HL7\Segment
 **Description**
 
 ```php
- getBarrierDelta (void)
+public getBarrierDelta (int $position)
 ```
 
- 
+Get Barrier Delta (OBR.18) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 18  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
 
 
 <hr />
@@ -241,20 +257,23 @@ Aranyasen\HL7\Segment
 **Description**
 
 ```php
- getBottomDelta (void)
+public getBottomDelta (int $position)
 ```
 
- 
+Get Bottom Delta (OBR.19) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 19  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
 
 
 <hr />
@@ -265,20 +284,23 @@ Aranyasen\HL7\Segment
 **Description**
 
 ```php
- getCapType (void)
+public getCapType (int $position)
 ```
 
- 
+Get Cap Type (OBR.26) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 26  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
 
 
 <hr />
@@ -289,20 +311,23 @@ Aranyasen\HL7\Segment
 **Description**
 
 ```php
- getCarrierIdentifier (void)
+public getCarrierIdentifier (int $position)
 ```
 
- 
+Get Carrier Identifier (OBR.10) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 10  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
 
 
 <hr />
@@ -313,20 +338,23 @@ Aranyasen\HL7\Segment
 **Description**
 
 ```php
- getCarrierType (void)
+public getCarrierType (int $position)
 ```
 
- 
+Get Carrier Type (OBR.9) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 9  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
 
 
 <hr />
@@ -337,20 +365,23 @@ Aranyasen\HL7\Segment
 **Description**
 
 ```php
- getContainerDiameter (void)
+public getContainerDiameter (int $position)
 ```
 
- 
+Get Container Diameter (OBR.17) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 17  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
 
 
 <hr />
@@ -361,20 +392,23 @@ Aranyasen\HL7\Segment
 **Description**
 
 ```php
- getContainerHeight (void)
+public getContainerHeight (int $position)
 ```
 
- 
+Get Container Height (OBR.16) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 16  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
 
 
 <hr />
@@ -385,20 +419,23 @@ Aranyasen\HL7\Segment
 **Description**
 
 ```php
- getContainerIdentifier (void)
+public getContainerIdentifier (int $position)
 ```
 
- 
+Get Container Identifier (OBR.3) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 3  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
 
 
 <hr />
@@ -409,20 +446,23 @@ Aranyasen\HL7\Segment
 **Description**
 
 ```php
- getContainerSizeUnits (void)
+public getContainerSizeUnits (int $position)
 ```
 
- 
+Get Container SizeUnits (OBR.20) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 20  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
 
 
 <hr />
@@ -433,20 +473,23 @@ Aranyasen\HL7\Segment
 **Description**
 
 ```php
- getContainerStatus (void)
+public getContainerStatus (int $position)
 ```
 
- 
+Get Container Status (OBR.8) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 8  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
 
 
 <hr />
@@ -457,20 +500,23 @@ Aranyasen\HL7\Segment
 **Description**
 
 ```php
- getContainerVolume (void)
+public getContainerVolume (int $position)
 ```
 
- 
+Get Container Volume (OBR.21) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 21  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
 
 
 <hr />
@@ -481,20 +527,23 @@ Aranyasen\HL7\Segment
 **Description**
 
 ```php
- getDilutionFactor (void)
+public getDilutionFactor (int $position)
 ```
 
- 
+Get Dilution Factor (OBR.29) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 29  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
 
 
 <hr />
@@ -505,20 +554,23 @@ Aranyasen\HL7\Segment
 **Description**
 
 ```php
- getDrugInterference (void)
+public getDrugInterference (int $position)
 ```
 
- 
+Get Drug Interference (OBR.41) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 41  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
 
 
 <hr />
@@ -529,20 +581,23 @@ Aranyasen\HL7\Segment
 **Description**
 
 ```php
- getEquipmentContainerIdentifier (void)
+public getEquipmentContainerIdentifier (int $position)
 ```
 
- 
+Get Equipment ContainerIdentifier (OBR.5) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 5  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
 
 
 <hr />
@@ -553,20 +608,23 @@ Aranyasen\HL7\Segment
 **Description**
 
 ```php
- getExternalAccessionIdentifier (void)
+public getExternalAccessionIdentifier (int $position)
 ```
 
- 
+Get External AccessionIdentifier (OBR.1) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 1  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
 
 
 <hr />
@@ -577,20 +635,23 @@ Aranyasen\HL7\Segment
 **Description**
 
 ```php
- getFibrinIndex (void)
+public getFibrinIndex (int $position)
 ```
 
- 
+Get Fibrin Index (OBR.38) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 38  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
 
 
 <hr />
@@ -601,20 +662,23 @@ Aranyasen\HL7\Segment
 **Description**
 
 ```php
- getFibrinIndexUnits (void)
+public getFibrinIndexUnits (int $position)
 ```
 
- 
+Get Fibrin IndexUnits (OBR.39) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 39  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
 
 
 <hr />
@@ -625,20 +689,23 @@ Aranyasen\HL7\Segment
 **Description**
 
 ```php
- getHemolysisIndex (void)
+public getHemolysisIndex (int $position)
 ```
 
- 
+Get Hemolysis Index (OBR.32) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 32  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
 
 
 <hr />
@@ -649,20 +716,23 @@ Aranyasen\HL7\Segment
 **Description**
 
 ```php
- getHemolysisIndexUnits (void)
+public getHemolysisIndexUnits (int $position)
 ```
 
- 
+Get Hemolysis IndexUnits (OBR.33) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 33  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
 
 
 <hr />
@@ -673,20 +743,23 @@ Aranyasen\HL7\Segment
 **Description**
 
 ```php
- getIcterusIndex (void)
+public getIcterusIndex (int $position)
 ```
 
- 
+Get Icterus Index (OBR.36) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 36  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
 
 
 <hr />
@@ -697,20 +770,23 @@ Aranyasen\HL7\Segment
 **Description**
 
 ```php
- getIcterusIndexUnits (void)
+public getIcterusIndexUnits (int $position)
 ```
 
- 
+Get Icterus IndexUnits (OBR.37) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 37  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
 
 
 <hr />
@@ -721,20 +797,23 @@ Aranyasen\HL7\Segment
 **Description**
 
 ```php
- getInitialSpecimenVolume (void)
+public getInitialSpecimenVolume (int $position)
 ```
 
- 
+Get Initial SpecimenVolume (OBR.23) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 23  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
 
 
 <hr />
@@ -745,20 +824,23 @@ Aranyasen\HL7\Segment
 **Description**
 
 ```php
- getLepemiaIndex (void)
+public getLepemiaIndex (int $position)
 ```
 
- 
+Get Lepemia Index (OBR.34) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 34  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
 
 
 <hr />
@@ -769,20 +851,23 @@ Aranyasen\HL7\Segment
 **Description**
 
 ```php
- getLepemiaIndexUnits (void)
+public getLepemiaIndexUnits (int $position)
 ```
 
- 
+Get Lepemia IndexUnits (OBR.35) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 35  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
 
 
 <hr />
@@ -793,20 +878,23 @@ Aranyasen\HL7\Segment
 **Description**
 
 ```php
- getLocation (void)
+public getLocation (int $position)
 ```
 
- 
+Get Location (OBR.15) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 15  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
 
 
 <hr />
@@ -817,20 +905,23 @@ Aranyasen\HL7\Segment
 **Description**
 
 ```php
- getOtherEnvironmentalFactors (void)
+public getOtherEnvironmentalFactors (int $position)
 ```
 
- 
+Get Other EnvironmentalFactors (OBR.44) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 44  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
 
 
 <hr />
@@ -841,20 +932,23 @@ Aranyasen\HL7\Segment
 **Description**
 
 ```php
- getPositionInCarrier (void)
+public getPositionInCarrier (int $position)
 ```
 
- 
+Get Position InCarrier (OBR.11) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 11  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
 
 
 <hr />
@@ -865,20 +959,23 @@ Aranyasen\HL7\Segment
 **Description**
 
 ```php
- getPositionInTray (void)
+public getPositionInTray (int $position)
 ```
 
- 
+Get Position InTray (OBR.14) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 14  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
 
 
 <hr />
@@ -889,20 +986,23 @@ Aranyasen\HL7\Segment
 **Description**
 
 ```php
- getPrimaryContainerIdentifier (void)
+public getPrimaryContainerIdentifier (int $position)
 ```
 
- 
+Get Primary ContainerIdentifier (OBR.4) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 4  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
 
 
 <hr />
@@ -913,20 +1013,23 @@ Aranyasen\HL7\Segment
 **Description**
 
 ```php
- getRegistrationDateTime (void)
+public getRegistrationDateTime (int $position)
 ```
 
- 
+Get Registration DateTime (OBR.7) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 7  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
 
 
 <hr />
@@ -937,20 +1040,23 @@ Aranyasen\HL7\Segment
 **Description**
 
 ```php
- getSeparatorType (void)
+public getSeparatorType (int $position)
 ```
 
- 
+Get Separator Type (OBR.25) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 25  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
 
 
 <hr />
@@ -961,20 +1067,23 @@ Aranyasen\HL7\Segment
 **Description**
 
 ```php
- getSpecialHandlingCode (void)
+public getSpecialHandlingCode (int $position)
 ```
 
- 
+Get Special HandlingCode (OBR.43) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 43  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
 
 
 <hr />
@@ -985,20 +1094,23 @@ Aranyasen\HL7\Segment
 **Description**
 
 ```php
- getSpecimenComponent (void)
+public getSpecimenComponent (int $position)
 ```
 
- 
+Get Specimen Component (OBR.28) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 28  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
 
 
 <hr />
@@ -1009,20 +1121,23 @@ Aranyasen\HL7\Segment
 **Description**
 
 ```php
- getSpecimenSource (void)
+public getSpecimenSource (int $position)
 ```
 
- 
+Get Specimen Source (OBR.6) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 6  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
 
 
 <hr />
@@ -1033,20 +1148,23 @@ Aranyasen\HL7\Segment
 **Description**
 
 ```php
- getSystemInducedContaminants (void)
+public getSystemInducedContaminants (int $position)
 ```
 
- 
+Get System InducedContaminants (OBR.40) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 40  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
 
 
 <hr />
@@ -1057,20 +1175,23 @@ Aranyasen\HL7\Segment
 **Description**
 
 ```php
- getTemperature (void)
+public getTemperature (int $position)
 ```
 
- 
+Get Temperature (OBR.31) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 31  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
 
 
 <hr />
@@ -1081,20 +1202,23 @@ Aranyasen\HL7\Segment
 **Description**
 
 ```php
- getTrayIdentifier (void)
+public getTrayIdentifier (int $position)
 ```
 
- 
+Get Tray Identifier (OBR.13) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 13  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
 
 
 <hr />
@@ -1105,20 +1229,23 @@ Aranyasen\HL7\Segment
 **Description**
 
 ```php
- getTrayTypeSAC (void)
+public getTrayTypeSAC (int $position)
 ```
 
- 
+Get Tray TypeSAC (OBR.12) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 12  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
 
 
 <hr />
@@ -1129,20 +1256,23 @@ Aranyasen\HL7\Segment
 **Description**
 
 ```php
- getTreatment (void)
+public getTreatment (int $position)
 ```
 
- 
+Get Treatment (OBR.30) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 30  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
 
 
 <hr />
@@ -1153,20 +1283,23 @@ Aranyasen\HL7\Segment
 **Description**
 
 ```php
- getVolumeUnits (void)
+public getVolumeUnits (int $position)
 ```
 
- 
+Get Volume Units (OBR.24) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(int) $position`
+: Defaults to 24  
 
 **Return Values**
 
-`void`
+`array|string|int|null`
+
+
 
 
 <hr />
@@ -1177,7 +1310,7 @@ Aranyasen\HL7\Segment
 **Description**
 
 ```php
-public static resetIndex (int $index)
+public static resetIndex (void)
 ```
 
 Reset index of this segment 
@@ -1186,7 +1319,7 @@ Reset index of this segment
 
 **Parameters**
 
-* `(int) $index`
+`This function has no parameters.`
 
 **Return Values**
 
@@ -1201,20 +1334,24 @@ Reset index of this segment
 **Description**
 
 ```php
- setAccessionIdentifier (void)
+public setAccessionIdentifier (string|int|array|null $value, int $position)
 ```
 
- 
+Set Accession Identifier (OBR.2) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 2  
 
 **Return Values**
 
-`void`
+`bool`
+
+
 
 
 <hr />
@@ -1225,20 +1362,24 @@ Reset index of this segment
 **Description**
 
 ```php
- setAdditive (void)
+public setAdditive (string|int|array|null $value, int $position)
 ```
 
- 
+Set Additive (OBR.27) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 27  
 
 **Return Values**
 
-`void`
+`bool`
+
+
 
 
 <hr />
@@ -1249,20 +1390,24 @@ Reset index of this segment
 **Description**
 
 ```php
- setArtificialBlood (void)
+public setArtificialBlood (string|int|array|null $value, int $position)
 ```
 
- 
+Set Artificial Blood (OBR.42) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 42  
 
 **Return Values**
 
-`void`
+`bool`
+
+
 
 
 <hr />
@@ -1273,20 +1418,24 @@ Reset index of this segment
 **Description**
 
 ```php
- setAvailableSpecimenVolume (void)
+public setAvailableSpecimenVolume (string|int|array|null $value, int $position)
 ```
 
- 
+Set Available SpecimenVolume (OBR.22) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 22  
 
 **Return Values**
 
-`void`
+`bool`
+
+
 
 
 <hr />
@@ -1297,20 +1446,24 @@ Reset index of this segment
 **Description**
 
 ```php
- setBarrierDelta (void)
+public setBarrierDelta (string|int|array|null $value, int $position)
 ```
 
- 
+Set Barrier Delta (OBR.18) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 18  
 
 **Return Values**
 
-`void`
+`bool`
+
+
 
 
 <hr />
@@ -1321,20 +1474,24 @@ Reset index of this segment
 **Description**
 
 ```php
- setBottomDelta (void)
+public setBottomDelta (string|int|array|null $value, int $position)
 ```
 
- 
+Set Bottom Delta (OBR.19) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 19  
 
 **Return Values**
 
-`void`
+`bool`
+
+
 
 
 <hr />
@@ -1345,20 +1502,24 @@ Reset index of this segment
 **Description**
 
 ```php
- setCapType (void)
+public setCapType (string|int|array|null $value, int $position)
 ```
 
- 
+Set Cap Type (OBR.26) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 26  
 
 **Return Values**
 
-`void`
+`bool`
+
+
 
 
 <hr />
@@ -1369,20 +1530,24 @@ Reset index of this segment
 **Description**
 
 ```php
- setCarrierIdentifier (void)
+public setCarrierIdentifier (string|int|array|null $value, int $position)
 ```
 
- 
+Set Carrier Identifier (OBR.10) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 10  
 
 **Return Values**
 
-`void`
+`bool`
+
+
 
 
 <hr />
@@ -1393,20 +1558,24 @@ Reset index of this segment
 **Description**
 
 ```php
- setCarrierType (void)
+public setCarrierType (string|int|array|null $value, int $position)
 ```
 
- 
+Set Carrier Type (OBR.9) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 9  
 
 **Return Values**
 
-`void`
+`bool`
+
+
 
 
 <hr />
@@ -1417,20 +1586,24 @@ Reset index of this segment
 **Description**
 
 ```php
- setContainerDiameter (void)
+public setContainerDiameter (string|int|array|null $value, int $position)
 ```
 
- 
+Set Container Diameter (OBR.17) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 17  
 
 **Return Values**
 
-`void`
+`bool`
+
+
 
 
 <hr />
@@ -1441,20 +1614,24 @@ Reset index of this segment
 **Description**
 
 ```php
- setContainerHeight (void)
+public setContainerHeight (string|int|array|null $value, int $position)
 ```
 
- 
+Set Container Height (OBR.16) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 16  
 
 **Return Values**
 
-`void`
+`bool`
+
+
 
 
 <hr />
@@ -1465,20 +1642,24 @@ Reset index of this segment
 **Description**
 
 ```php
- setContainerIdentifier (void)
+public setContainerIdentifier (string|int|array|null $value, int $position)
 ```
 
- 
+Set Container Identifier (OBR.3) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 3  
 
 **Return Values**
 
-`void`
+`bool`
+
+
 
 
 <hr />
@@ -1489,20 +1670,24 @@ Reset index of this segment
 **Description**
 
 ```php
- setContainerSizeUnits (void)
+public setContainerSizeUnits (string|int|array|null $value, int $position)
 ```
 
- 
+Set Container SizeUnits (OBR.20) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 20  
 
 **Return Values**
 
-`void`
+`bool`
+
+
 
 
 <hr />
@@ -1513,20 +1698,24 @@ Reset index of this segment
 **Description**
 
 ```php
- setContainerStatus (void)
+public setContainerStatus (string|int|array|null $value, int $position)
 ```
 
- 
+Set Container Status (OBR.8) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 8  
 
 **Return Values**
 
-`void`
+`bool`
+
+
 
 
 <hr />
@@ -1537,20 +1726,24 @@ Reset index of this segment
 **Description**
 
 ```php
- setContainerVolume (void)
+public setContainerVolume (string|int|array|null $value, int $position)
 ```
 
- 
+Set Container Volume (OBR.21) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 21  
 
 **Return Values**
 
-`void`
+`bool`
+
+
 
 
 <hr />
@@ -1561,20 +1754,24 @@ Reset index of this segment
 **Description**
 
 ```php
- setDilutionFactor (void)
+public setDilutionFactor (string|int|array|null $value, int $position)
 ```
 
- 
+Set Dilution Factor (OBR.29) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 29  
 
 **Return Values**
 
-`void`
+`bool`
+
+
 
 
 <hr />
@@ -1585,20 +1782,24 @@ Reset index of this segment
 **Description**
 
 ```php
- setDrugInterference (void)
+public setDrugInterference (string|int|array|null $value, int $position)
 ```
 
- 
+Set Drug Interference (OBR.41) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 41  
 
 **Return Values**
 
-`void`
+`bool`
+
+
 
 
 <hr />
@@ -1609,20 +1810,24 @@ Reset index of this segment
 **Description**
 
 ```php
- setEquipmentContainerIdentifier (void)
+public setEquipmentContainerIdentifier (string|int|array|null $value, int $position)
 ```
 
- 
+Set Equipment ContainerIdentifier (OBR.5) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 5  
 
 **Return Values**
 
-`void`
+`bool`
+
+
 
 
 <hr />
@@ -1657,20 +1862,24 @@ Reset index of this segment
 **Description**
 
 ```php
- setFibrinIndex (void)
+public setFibrinIndex (string|int|array|null $value, int $position)
 ```
 
- 
+Set Fibrin Index (OBR.38) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 38  
 
 **Return Values**
 
-`void`
+`bool`
+
+
 
 
 <hr />
@@ -1681,20 +1890,24 @@ Reset index of this segment
 **Description**
 
 ```php
- setFibrinIndexUnits (void)
+public setFibrinIndexUnits (string|int|array|null $value, int $position)
 ```
 
- 
+Set Fibrin IndexUnits (OBR.39) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 39  
 
 **Return Values**
 
-`void`
+`bool`
+
+
 
 
 <hr />
@@ -1705,20 +1918,24 @@ Reset index of this segment
 **Description**
 
 ```php
- setHemolysisIndex (void)
+public setHemolysisIndex (string|int|array|null $value, int $position)
 ```
 
- 
+Set Hemolysis Index (OBR.32) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 32  
 
 **Return Values**
 
-`void`
+`bool`
+
+
 
 
 <hr />
@@ -1729,20 +1946,24 @@ Reset index of this segment
 **Description**
 
 ```php
- setHemolysisIndexUnits (void)
+public setHemolysisIndexUnits (string|int|array|null $value, int $position)
 ```
 
- 
+Set Hemolysis IndexUnits (OBR.33) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 33  
 
 **Return Values**
 
-`void`
+`bool`
+
+
 
 
 <hr />
@@ -1753,20 +1974,24 @@ Reset index of this segment
 **Description**
 
 ```php
- setIcterusIndex (void)
+public setIcterusIndex (string|int|array|null $value, int $position)
 ```
 
- 
+Set Icterus Index (OBR.36) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 36  
 
 **Return Values**
 
-`void`
+`bool`
+
+
 
 
 <hr />
@@ -1777,20 +2002,24 @@ Reset index of this segment
 **Description**
 
 ```php
- setIcterusIndexUnits (void)
+public setIcterusIndexUnits (string|int|array|null $value, int $position)
 ```
 
- 
+Set Icterus IndexUnits (OBR.37) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 37  
 
 **Return Values**
 
-`void`
+`bool`
+
+
 
 
 <hr />
@@ -1801,20 +2030,24 @@ Reset index of this segment
 **Description**
 
 ```php
- setInitialSpecimenVolume (void)
+public setInitialSpecimenVolume (string|int|array|null $value, int $position)
 ```
 
- 
+Set Initial SpecimenVolume (OBR.23) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 23  
 
 **Return Values**
 
-`void`
+`bool`
+
+
 
 
 <hr />
@@ -1825,20 +2058,24 @@ Reset index of this segment
 **Description**
 
 ```php
- setLepemiaIndex (void)
+public setLepemiaIndex (string|int|array|null $value, int $position)
 ```
 
- 
+Set Lepemia Index (OBR.34) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 34  
 
 **Return Values**
 
-`void`
+`bool`
+
+
 
 
 <hr />
@@ -1849,20 +2086,24 @@ Reset index of this segment
 **Description**
 
 ```php
- setLepemiaIndexUnits (void)
+public setLepemiaIndexUnits (string|int|array|null $value, int $position)
 ```
 
- 
+Set Lepemia IndexUnits (OBR.35) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 35  
 
 **Return Values**
 
-`void`
+`bool`
+
+
 
 
 <hr />
@@ -1873,20 +2114,24 @@ Reset index of this segment
 **Description**
 
 ```php
- setLocation (void)
+public setLocation (string|int|array|null $value, int $position)
 ```
 
- 
+Set Location (OBR.15) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 15  
 
 **Return Values**
 
-`void`
+`bool`
+
+
 
 
 <hr />
@@ -1897,20 +2142,24 @@ Reset index of this segment
 **Description**
 
 ```php
- setOtherEnvironmentalFactors (void)
+public setOtherEnvironmentalFactors (string|int|array|null $value, int $position)
 ```
 
- 
+Set Other EnvironmentalFactors (OBR.44) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 44  
 
 **Return Values**
 
-`void`
+`bool`
+
+
 
 
 <hr />
@@ -1921,20 +2170,24 @@ Reset index of this segment
 **Description**
 
 ```php
- setPositionInCarrier (void)
+public setPositionInCarrier (string|int|array|null $value, int $position)
 ```
 
- 
+Set Position InCarrier (OBR.11) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 11  
 
 **Return Values**
 
-`void`
+`bool`
+
+
 
 
 <hr />
@@ -1945,20 +2198,24 @@ Reset index of this segment
 **Description**
 
 ```php
- setPositionInTray (void)
+public setPositionInTray (string|int|array|null $value, int $position)
 ```
 
- 
+Set Position InTray (OBR.14) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 14  
 
 **Return Values**
 
-`void`
+`bool`
+
+
 
 
 <hr />
@@ -1969,20 +2226,24 @@ Reset index of this segment
 **Description**
 
 ```php
- setPrimaryContainerIdentifier (void)
+public setPrimaryContainerIdentifier (string|int|array|null $value, int $position)
 ```
 
- 
+Set Primary ContainerIdentifier (OBR.4) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 4  
 
 **Return Values**
 
-`void`
+`bool`
+
+
 
 
 <hr />
@@ -1993,20 +2254,24 @@ Reset index of this segment
 **Description**
 
 ```php
- setRegistrationDateTime (void)
+public setRegistrationDateTime (string|int|array|null $value, int $position)
 ```
 
- 
+Set Registration DateTime (OBR.7) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 7  
 
 **Return Values**
 
-`void`
+`bool`
+
+
 
 
 <hr />
@@ -2017,20 +2282,24 @@ Reset index of this segment
 **Description**
 
 ```php
- setSeparatorType (void)
+public setSeparatorType (string|int|array|null $value, int $position)
 ```
 
- 
+Set Separator Type (OBR.25) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 25  
 
 **Return Values**
 
-`void`
+`bool`
+
+
 
 
 <hr />
@@ -2041,20 +2310,24 @@ Reset index of this segment
 **Description**
 
 ```php
- setSpecialHandlingCode (void)
+public setSpecialHandlingCode (string|int|array|null $value, int $position)
 ```
 
- 
+Set Special HandlingCode (OBR.43) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 43  
 
 **Return Values**
 
-`void`
+`bool`
+
+
 
 
 <hr />
@@ -2065,20 +2338,24 @@ Reset index of this segment
 **Description**
 
 ```php
- setSpecimenComponent (void)
+public setSpecimenComponent (string|int|array|null $value, int $position)
 ```
 
- 
+Set Specimen Component (OBR.28) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 28  
 
 **Return Values**
 
-`void`
+`bool`
+
+
 
 
 <hr />
@@ -2089,20 +2366,24 @@ Reset index of this segment
 **Description**
 
 ```php
- setSpecimenSource (void)
+public setSpecimenSource (string|int|array|null $value, int $position)
 ```
 
- 
+Set Specimen Source (OBR.6) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 6  
 
 **Return Values**
 
-`void`
+`bool`
+
+
 
 
 <hr />
@@ -2113,20 +2394,24 @@ Reset index of this segment
 **Description**
 
 ```php
- setSystemInducedContaminants (void)
+public setSystemInducedContaminants (string|int|array|null $value, int $position)
 ```
 
- 
+Set System InducedContaminants (OBR.40) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 40  
 
 **Return Values**
 
-`void`
+`bool`
+
+
 
 
 <hr />
@@ -2137,20 +2422,24 @@ Reset index of this segment
 **Description**
 
 ```php
- setTemperature (void)
+public setTemperature (string|int|array|null $value, int $position)
 ```
 
- 
+Set Temperature (OBR.31) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 31  
 
 **Return Values**
 
-`void`
+`bool`
+
+
 
 
 <hr />
@@ -2161,20 +2450,24 @@ Reset index of this segment
 **Description**
 
 ```php
- setTrayIdentifier (void)
+public setTrayIdentifier (string|int|array|null $value, int $position)
 ```
 
- 
+Set Tray Identifier (OBR.13) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 13  
 
 **Return Values**
 
-`void`
+`bool`
+
+
 
 
 <hr />
@@ -2185,20 +2478,24 @@ Reset index of this segment
 **Description**
 
 ```php
- setTrayTypeSAC (void)
+public setTrayTypeSAC (string|int|array|null $value, int $position)
 ```
 
- 
+Set Tray TypeSAC (OBR.12) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 12  
 
 **Return Values**
 
-`void`
+`bool`
+
+
 
 
 <hr />
@@ -2209,20 +2506,24 @@ Reset index of this segment
 **Description**
 
 ```php
- setTreatment (void)
+public setTreatment (string|int|array|null $value, int $position)
 ```
 
- 
+Set Treatment (OBR.30) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 30  
 
 **Return Values**
 
-`void`
+`bool`
+
+
 
 
 <hr />
@@ -2233,20 +2534,24 @@ Reset index of this segment
 **Description**
 
 ```php
- setVolumeUnits (void)
+public setVolumeUnits (string|int|array|null $value, int $position)
 ```
 
- 
+Set Volume Units (OBR.24) 
 
  
 
 **Parameters**
 
-`This function has no parameters.`
+* `(string|int|array|null) $value`
+* `(int) $position`
+: Defaults to 24  
 
 **Return Values**
 
-`void`
+`bool`
+
+
 
 
 <hr />

--- a/src/HL7/Segments/AIG.php
+++ b/src/HL7/Segments/AIG.php
@@ -50,136 +50,365 @@ class AIG extends Segment
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Segment ActionCode (OBR.2)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 2
+     *
+     * @return bool
+     *
+     */
     public function setSegmentActionCode($value, int $position = 2): bool
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Resource ID (OBR.3)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 3
+     *
+     * @return bool
+     *
+     */
     public function setResourceID($value, int $position = 3): bool
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Resource Type (OBR.4)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 4
+     *
+     * @return bool
+     *
+     */
     public function setResourceType($value, int $position = 4): bool
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Resource Group (OBR.5)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 5
+     *
+     * @return bool
+     *
+     */
     public function setResourceGroup($value, int $position = 5): bool
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Resource Quantity (OBR.6)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 6
+     *
+     * @return bool
+     *
+     */
     public function setResourceQuantity($value, int $position = 6): bool
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Resource QuantityUnits (OBR.7)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 7
+     *
+     * @return bool
+     *
+     */
     public function setResourceQuantityUnits($value, int $position = 7): bool
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Start DateTime (OBR.8)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 8
+     *
+     * @return bool
+     *
+     */
     public function setStartDateTime($value, int $position = 8): bool
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Start DateTimeOffset (OBR.9)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 9
+     *
+     * @return bool
+     *
+     */
     public function setStartDateTimeOffset($value, int $position = 9): bool
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Start DateTimeOffsetUnits (OBR.10)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 10
+     *
+     * @return bool
+     *
+     */
     public function setStartDateTimeOffsetUnits($value, int $position = 10): bool
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Duration (OBR.11)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 11
+     *
+     * @return bool
+     *
+     */
     public function setDuration($value, int $position = 11): bool
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Duration Units (OBR.12)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 12
+     *
+     * @return bool
+     *
+     */
     public function setDurationUnits($value, int $position = 12): bool
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Allow SubstitutionCode (OBR.13)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 13
+     *
+     * @return bool
+     *
+     */
     public function setAllowSubstitutionCode($value, int $position = 13): bool
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Filler StatusCode (OBR.14)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 14
+     *
+     * @return bool
+     *
+     */
     public function setFillerStatusCode($value, int $position = 14): bool
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Get ID (OBR.1)
+     *
+     * @param int $position Defaults to 1
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getID(int $position = 1)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Segment ActionCode (OBR.2)
+     *
+     * @param int $position Defaults to 2
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getSegmentActionCode(int $position = 2)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Resource ID (OBR.3)
+     *
+     * @param int $position Defaults to 3
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getResourceID(int $position = 3)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Resource Type (OBR.4)
+     *
+     * @param int $position Defaults to 4
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getResourceType(int $position = 4)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Resource Group (OBR.5)
+     *
+     * @param int $position Defaults to 5
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getResourceGroup(int $position = 5)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Resource Quantity (OBR.6)
+     *
+     * @param int $position Defaults to 6
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getResourceQuantity(int $position = 6)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Resource QuantityUnits (OBR.7)
+     *
+     * @param int $position Defaults to 7
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getResourceQuantityUnits(int $position = 7)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Start DateTime (OBR.8)
+     *
+     * @param int $position Defaults to 8
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getStartDateTime(int $position = 8)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Start DateTimeOffset (OBR.9)
+     *
+     * @param int $position Defaults to 9
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getStartDateTimeOffset(int $position = 9)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Start DateTimeOffsetUnits (OBR.10)
+     *
+     * @param int $position Defaults to 10
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getStartDateTimeOffsetUnits(int $position = 10)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Duration (OBR.11)
+     *
+     * @param int $position Defaults to 11
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getDuration(int $position = 11)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Duration Units (OBR.12)
+     *
+     * @param int $position Defaults to 12
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getDurationUnits(int $position = 12)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Allow SubstitutionCode (OBR.13)
+     *
+     * @param int $position Defaults to 13
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getAllowSubstitutionCode(int $position = 13)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Filler StatusCode (OBR.14)
+     *
+     * @param int $position Defaults to 14
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getFillerStatusCode(int $position = 14)
     {
         return $this->getField($position);

--- a/src/HL7/Segments/AIL.php
+++ b/src/HL7/Segments/AIL.php
@@ -51,116 +51,311 @@ class AIL extends Segment
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Segment ActionCode (OBR.2)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 2
+     *
+     * @return bool
+     *
+     */
     public function setSegmentActionCode($value, int $position = 2): bool
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Location ResourceID (OBR.3)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 3
+     *
+     * @return bool
+     *
+     */
     public function setLocationResourceID($value, int $position = 3): bool
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Location TypeAIL (OBR.4)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 4
+     *
+     * @return bool
+     *
+     */
     public function setLocationTypeAIL($value, int $position = 4): bool
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Location Group (OBR.5)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 5
+     *
+     * @return bool
+     *
+     */
     public function setLocationGroup($value, int $position = 5): bool
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Start DateTime (OBR.6)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 6
+     *
+     * @return bool
+     *
+     */
     public function setStartDateTime($value, int $position = 6): bool
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Start DateTimeOffset (OBR.7)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 7
+     *
+     * @return bool
+     *
+     */
     public function setStartDateTimeOffset($value, int $position = 7): bool
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Start DateTimeOffsetUnits (OBR.8)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 8
+     *
+     * @return bool
+     *
+     */
     public function setStartDateTimeOffsetUnits($value, int $position = 8): bool
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Duration (OBR.9)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 9
+     *
+     * @return bool
+     *
+     */
     public function setDuration($value, int $position = 9): bool
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Duration Units (OBR.10)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 10
+     *
+     * @return bool
+     *
+     */
     public function setDurationUnits($value, int $position = 10): bool
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Allow SubstitutionCode (OBR.11)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 11
+     *
+     * @return bool
+     *
+     */
     public function setAllowSubstitutionCode($value, int $position = 11): bool
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Filler StatusCode (OBR.12)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 12
+     *
+     * @return bool
+     *
+     */
     public function setFillerStatusCode($value, int $position = 12): bool
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Get ID (OBR.1)
+     *
+     * @param int $position Defaults to 1
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getID(int $position = 1)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Segment ActionCode (OBR.2)
+     *
+     * @param int $position Defaults to 2
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getSegmentActionCode(int $position = 2)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Location ResourceID (OBR.3)
+     *
+     * @param int $position Defaults to 3
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getLocationResourceID(int $position = 3)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Location TypeAIL (OBR.4)
+     *
+     * @param int $position Defaults to 4
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getLocationTypeAIL(int $position = 4)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Location Group (OBR.5)
+     *
+     * @param int $position Defaults to 5
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getLocationGroup(int $position = 5)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Start DateTime (OBR.6)
+     *
+     * @param int $position Defaults to 6
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getStartDateTime(int $position = 6)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Start DateTimeOffset (OBR.7)
+     *
+     * @param int $position Defaults to 7
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getStartDateTimeOffset(int $position = 7)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Start DateTimeOffsetUnits (OBR.8)
+     *
+     * @param int $position Defaults to 8
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getStartDateTimeOffsetUnits(int $position = 8)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Duration (OBR.9)
+     *
+     * @param int $position Defaults to 9
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getDuration(int $position = 9)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Duration Units (OBR.10)
+     *
+     * @param int $position Defaults to 10
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getDurationUnits(int $position = 10)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Allow SubstitutionCode (OBR.11)
+     *
+     * @param int $position Defaults to 11
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getAllowSubstitutionCode(int $position = 11)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Filler StatusCode (OBR.12)
+     *
+     * @param int $position Defaults to 12
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getFillerStatusCode(int $position = 12)
     {
         return $this->getField($position);

--- a/src/HL7/Segments/AIP.php
+++ b/src/HL7/Segments/AIP.php
@@ -51,116 +51,311 @@ class AIP extends Segment
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Segment ActionCode (OBR.2)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 2
+     *
+     * @return bool
+     *
+     */
     public function setSegmentActionCode($value, int $position = 2): bool
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Personnel ResourceID (OBR.3)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 3
+     *
+     * @return bool
+     *
+     */
     public function setPersonnelResourceID($value, int $position = 3): bool
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Resource Type (OBR.4)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 4
+     *
+     * @return bool
+     *
+     */
     public function setResourceType($value, int $position = 4): bool
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Resource Group (OBR.5)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 5
+     *
+     * @return bool
+     *
+     */
     public function setResourceGroup($value, int $position = 5): bool
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Start DateTime (OBR.6)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 6
+     *
+     * @return bool
+     *
+     */
     public function setStartDateTime($value, int $position = 6): bool
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Start DateTimeOffset (OBR.7)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 7
+     *
+     * @return bool
+     *
+     */
     public function setStartDateTimeOffset($value, int $position = 7): bool
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Start DateTimeOffsetUnits (OBR.8)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 8
+     *
+     * @return bool
+     *
+     */
     public function setStartDateTimeOffsetUnits($value, int $position = 8): bool
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Duration (OBR.9)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 9
+     *
+     * @return bool
+     *
+     */
     public function setDuration($value, int $position = 9): bool
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Duration Units (OBR.10)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 10
+     *
+     * @return bool
+     *
+     */
     public function setDurationUnits($value, int $position = 10): bool
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Allow SubstitutionCode (OBR.11)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 11
+     *
+     * @return bool
+     *
+     */
     public function setAllowSubstitutionCode($value, int $position = 11): bool
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Filler StatusCode (OBR.12)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 12
+     *
+     * @return bool
+     *
+     */
     public function setFillerStatusCode($value, int $position = 12): bool
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Get ID (OBR.1)
+     *
+     * @param int $position Defaults to 1
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getID(int $position = 1)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Segment ActionCode (OBR.2)
+     *
+     * @param int $position Defaults to 2
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getSegmentActionCode(int $position = 2)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Personnel ResourceID (OBR.3)
+     *
+     * @param int $position Defaults to 3
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getPersonnelResourceID(int $position = 3)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Resource Type (OBR.4)
+     *
+     * @param int $position Defaults to 4
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getResourceType(int $position = 4)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Resource Group (OBR.5)
+     *
+     * @param int $position Defaults to 5
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getResourceGroup(int $position = 5)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Start DateTime (OBR.6)
+     *
+     * @param int $position Defaults to 6
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getStartDateTime(int $position = 6)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Start DateTimeOffset (OBR.7)
+     *
+     * @param int $position Defaults to 7
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getStartDateTimeOffset(int $position = 7)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Start DateTimeOffsetUnits (OBR.8)
+     *
+     * @param int $position Defaults to 8
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getStartDateTimeOffsetUnits(int $position = 8)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Duration (OBR.9)
+     *
+     * @param int $position Defaults to 9
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getDuration(int $position = 9)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Duration Units (OBR.10)
+     *
+     * @param int $position Defaults to 10
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getDurationUnits(int $position = 10)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Allow SubstitutionCode (OBR.11)
+     *
+     * @param int $position Defaults to 11
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getAllowSubstitutionCode(int $position = 11)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Filler StatusCode (OBR.12)
+     *
+     * @param int $position Defaults to 12
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getFillerStatusCode(int $position = 12)
     {
         return $this->getField($position);

--- a/src/HL7/Segments/DG1.php
+++ b/src/HL7/Segments/DG1.php
@@ -43,6 +43,15 @@ class DG1 extends Segment
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Diagnosis CodingMethod (OBR.2)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 2
+     *
+     * @return bool
+     *
+     */
     public function setDiagnosisCodingMethod($value, int $position = 2)
     {
         return $this->setField($position, $value);
@@ -53,91 +62,251 @@ class DG1 extends Segment
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Diagnosis Description (OBR.4)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 4
+     *
+     * @return bool
+     *
+     */
     public function setDiagnosisDescription($value, int $position = 4)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Diagnosis DateTime (OBR.5)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 5
+     *
+     * @return bool
+     *
+     */
     public function setDiagnosisDateTime($value, int $position = 5)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Diagnosis Type (OBR.6)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 6
+     *
+     * @return bool
+     *
+     */
     public function setDiagnosisType($value, int $position = 6)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Major DiagnosticCategory (OBR.7)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 7
+     *
+     * @return bool
+     *
+     */
     public function setMajorDiagnosticCategory($value, int $position = 7)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Diagnostic RelatedGroup (OBR.8)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 8
+     *
+     * @return bool
+     *
+     */
     public function setDiagnosticRelatedGroup($value, int $position = 8)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set DRGApproval Indicator (OBR.9)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 9
+     *
+     * @return bool
+     *
+     */
     public function setDRGApprovalIndicator($value, int $position = 9)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set DRGGrouper ReviewCode (OBR.10)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 10
+     *
+     * @return bool
+     *
+     */
     public function setDRGGrouperReviewCode($value, int $position = 10)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Outlier Type (OBR.11)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 11
+     *
+     * @return bool
+     *
+     */
     public function setOutlierType($value, int $position = 11)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Outlier Days (OBR.12)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 12
+     *
+     * @return bool
+     *
+     */
     public function setOutlierDays($value, int $position = 12)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Outlier Cost (OBR.13)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 13
+     *
+     * @return bool
+     *
+     */
     public function setOutlierCost($value, int $position = 13)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Grouper VersionAndType (OBR.14)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 14
+     *
+     * @return bool
+     *
+     */
     public function setGrouperVersionAndType($value, int $position = 14)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Diagnosis Priority (OBR.15)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 15
+     *
+     * @return bool
+     *
+     */
     public function setDiagnosisPriority($value, int $position = 15)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Diagnosing Clinician (OBR.16)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 16
+     *
+     * @return bool
+     *
+     */
     public function setDiagnosingClinician($value, int $position = 16)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Diagnosis Classification (OBR.17)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 17
+     *
+     * @return bool
+     *
+     */
     public function setDiagnosisClassification($value, int $position = 17)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Confidential Indicator (OBR.18)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 18
+     *
+     * @return bool
+     *
+     */
     public function setConfidentialIndicator($value, int $position = 18)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Attestation DateTime (OBR.19)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 19
+     *
+     * @return bool
+     *
+     */
     public function setAttestationDateTime($value, int $position = 19)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Get ID (OBR.1)
+     *
+     * @param int $position Defaults to 1
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getID(int $position = 1)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Diagnosis CodingMethod (OBR.2)
+     *
+     * @param int $position Defaults to 2
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getDiagnosisCodingMethod(int $position = 2)
     {
         return $this->getField($position);
@@ -148,81 +317,209 @@ class DG1 extends Segment
         return $this->getField($position);
     }
 
+    /**
+     * Get Diagnosis Description (OBR.4)
+     *
+     * @param int $position Defaults to 4
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getDiagnosisDescription(int $position = 4)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Diagnosis DateTime (OBR.5)
+     *
+     * @param int $position Defaults to 5
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getDiagnosisDateTime(int $position = 5)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Diagnosis Type (OBR.6)
+     *
+     * @param int $position Defaults to 6
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getDiagnosisType(int $position = 6)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Major DiagnosticCategory (OBR.7)
+     *
+     * @param int $position Defaults to 7
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getMajorDiagnosticCategory(int $position = 7)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Diagnostic RelatedGroup (OBR.8)
+     *
+     * @param int $position Defaults to 8
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getDiagnosticRelatedGroup(int $position = 8)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get DRGApproval Indicator (OBR.9)
+     *
+     * @param int $position Defaults to 9
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getDRGApprovalIndicator(int $position = 9)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get DRGGrouper ReviewCode (OBR.10)
+     *
+     * @param int $position Defaults to 10
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getDRGGrouperReviewCode(int $position = 10)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Outlier Type (OBR.11)
+     *
+     * @param int $position Defaults to 11
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getOutlierType(int $position = 11)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Outlier Days (OBR.12)
+     *
+     * @param int $position Defaults to 12
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getOutlierDays(int $position = 12)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Outlier Cost (OBR.13)
+     *
+     * @param int $position Defaults to 13
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getOutlierCost(int $position = 13)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Grouper VersionAndType (OBR.14)
+     *
+     * @param int $position Defaults to 14
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getGrouperVersionAndType(int $position = 14)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Diagnosis Priority (OBR.15)
+     *
+     * @param int $position Defaults to 15
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getDiagnosisPriority(int $position = 15)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Diagnosing Clinician (OBR.16)
+     *
+     * @param int $position Defaults to 16
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getDiagnosingClinician(int $position = 16)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Diagnosis Classification (OBR.17)
+     *
+     * @param int $position Defaults to 17
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getDiagnosisClassification(int $position = 17)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Confidential Indicator (OBR.18)
+     *
+     * @param int $position Defaults to 18
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getConfidentialIndicator(int $position = 18)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Attestation DateTime (OBR.19)
+     *
+     * @param int $position Defaults to 19
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getAttestationDateTime(int $position = 19)
     {
         return $this->getField($position);

--- a/src/HL7/Segments/EQU.php
+++ b/src/HL7/Segments/EQU.php
@@ -36,46 +36,122 @@ class EQU extends Segment
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Event DateTime (OBR.2)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 2
+     *
+     * @return bool
+     *
+     */
     public function setEventDateTime($value, int $position = 2)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Equipment State (OBR.3)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 3
+     *
+     * @return bool
+     *
+     */
     public function setEquipmentState($value, int $position = 3)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Local RemoteControlState (OBR.4)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 4
+     *
+     * @return bool
+     *
+     */
     public function setLocalRemoteControlState($value, int $position = 4)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Alert Level (OBR.5)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 5
+     *
+     * @return bool
+     *
+     */
     public function setAlertLevel($value, int $position = 5)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Get Equipment InstanceIdentifier (OBR.1)
+     *
+     * @param int $position Defaults to 1
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getEquipmentInstanceIdentifier(int $position = 1)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Event DateTime (OBR.2)
+     *
+     * @param int $position Defaults to 2
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getEventDateTime(int $position = 2)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Equipment State (OBR.3)
+     *
+     * @param int $position Defaults to 3
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getEquipmentState(int $position = 3)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Local RemoteControlState (OBR.4)
+     *
+     * @param int $position Defaults to 4
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getLocalRemoteControlState(int $position = 4)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Alert Level (OBR.4)
+     *
+     * @param int $position Defaults to 4
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getAlertLevel(int $position = 4)
     {
         return $this->getField($position);

--- a/src/HL7/Segments/EVN.php
+++ b/src/HL7/Segments/EVN.php
@@ -16,61 +16,163 @@ class EVN extends Segment
         parent::__construct('EVN', $fields);
     }
 
+    /**
+     * Set Event TypeCode (OBR.1)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 1
+     *
+     * @return bool
+     *
+     */
     public function setEventTypeCode($value, int $position = 1): bool
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Recorded DateTime (OBR.2)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 2
+     *
+     * @return bool
+     *
+     */
     public function setRecordedDateTime($value, int $position = 2): bool
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Date TimePlannedEvent (OBR.3)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 3
+     *
+     * @return bool
+     *
+     */
     public function setDateTimePlannedEvent($value, int $position = 3): bool
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Event ReasonCode (OBR.4)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 4
+     *
+     * @return bool
+     *
+     */
     public function setEventReasonCode($value, int $position = 4): bool
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Operator ID (OBR.5)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 5
+     *
+     * @return bool
+     *
+     */
     public function setOperatorID($value, int $position = 5): bool
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Event Occurred (OBR.6)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 6
+     *
+     * @return bool
+     *
+     */
     public function setEventOccurred($value, int $position = 6): bool
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Get Event TypeCode (OBR.1)
+     *
+     * @param int $position Defaults to 1
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getEventTypeCode(int $position = 1)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Recorded DateTime (OBR.2)
+     *
+     * @param int $position Defaults to 2
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getRecordedDateTime(int $position = 2)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Date TimePlannedEvent (OBR.3)
+     *
+     * @param int $position Defaults to 3
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getDateTimePlannedEvent(int $position = 3)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Event ReasonCode (OBR.4)
+     *
+     * @param int $position Defaults to 4
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getEventReasonCode(int $position = 4)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Operator ID (OBR.5)
+     *
+     * @param int $position Defaults to 5
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getOperatorID(int $position = 5)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Event Occurred (OBR.6)
+     *
+     * @param int $position Defaults to 6
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getEventOccurred(int $position = 6)
     {
         return $this->getField($position);

--- a/src/HL7/Segments/FHS.php
+++ b/src/HL7/Segments/FHS.php
@@ -17,61 +17,169 @@ class FHS extends Segment
         parent::__construct('FHS', $fields);
     }
 
+    /**
+     * Set File FieldSeparator (OBR.1)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 1
+     *
+     * @return bool
+     *
+     */
     public function setFileFieldSeparator($value, int $position = 1)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set File EncodingCharacters (OBR.2)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 2
+     *
+     * @return bool
+     *
+     */
     public function setFileEncodingCharacters($value, int $position = 2)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set File SendingApplication (OBR.3)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 3
+     *
+     * @return bool
+     *
+     */
     public function setFileSendingApplication($value, int $position = 3)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set File SendingFacility (OBR.4)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 4
+     *
+     * @return bool
+     *
+     */
     public function setFileSendingFacility($value, int $position = 4)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set File RecievingApplication (OBR.5)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 5
+     *
+     * @return bool
+     *
+     */
     public function setFileRecievingApplication($value, int $position = 5)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set File RecievingFacility (OBR.6)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 6
+     *
+     * @return bool
+     *
+     */
     public function setFileRecievingFacility($value, int $position = 6)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set File CreationDateTime (OBR.7)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 7
+     *
+     * @return bool
+     *
+     */
     public function setFileCreationDateTime($value, int $position = 7)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set File Security (OBR.8)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 8
+     *
+     * @return bool
+     *
+     */
     public function setFileSecurity($value, int $position = 8)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set File NameId (OBR.9)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 9
+     *
+     * @return bool
+     *
+     */
     public function setFileNameId($value, int $position = 9)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set File HeaderComment (OBR.10)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 10
+     *
+     * @return bool
+     *
+     */
     public function setFileHeaderComment($value, int $position = 10)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set File ControlId (OBR.11)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 11
+     *
+     * @return bool
+     *
+     */
     public function setFileControlId($value, int $position = 11)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Reference FileControlId (OBR.12)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 12
+     *
+     * @return bool
+     *
+     */
     public function setReferenceFileControlId($value, int $position = 12)
     {
         return $this->setField($position, $value);
@@ -79,61 +187,157 @@ class FHS extends Segment
 
     // -------------------- Getter Methods ------------------------------
 
+    /**
+     * Get File FieldSeparator (OBR.1)
+     *
+     * @param int $position Defaults to 1
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getFileFieldSeparator(int $position = 1)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get File EncodingCharacters (OBR.2)
+     *
+     * @param int $position Defaults to 2
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getFileEncodingCharacters(int $position = 2)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get File SendingApplication (OBR.3)
+     *
+     * @param int $position Defaults to 3
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getFileSendingApplication(int $position = 3)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get File SendingFacility (OBR.4)
+     *
+     * @param int $position Defaults to 4
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getFileSendingFacility(int $position = 4)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get File RecievingApplication (OBR.5)
+     *
+     * @param int $position Defaults to 5
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getFileRecievingApplication(int $position = 5)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get File RecievingFacility (OBR.6)
+     *
+     * @param int $position Defaults to 6
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getFileRecievingFacility(int $position = 6)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get File CreationDateTime (OBR.7)
+     *
+     * @param int $position Defaults to 7
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getFileCreationDateTime(int $position = 7)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get File Security (OBR.8)
+     *
+     * @param int $position Defaults to 8
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getFileSecurity(int $position = 8)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get File NameId (OBR.9)
+     *
+     * @param int $position Defaults to 9
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getFileNameId(int $position = 9)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get File HeaderComment (OBR.10)
+     *
+     * @param int $position Defaults to 10
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getFileHeaderComment(int $position = 10)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get File ControlId (OBR.11)
+     *
+     * @param int $position Defaults to 11
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getFileControlId(int $position = 11)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Reference FileControlId (OBR.12)
+     *
+     * @param int $position Defaults to 12
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getReferenceFileControlId(int $position = 12)
     {
         return $this->getField($position);

--- a/src/HL7/Segments/FTS.php
+++ b/src/HL7/Segments/FTS.php
@@ -17,11 +17,29 @@ class FTS extends Segment
         parent::__construct('FTS', $fields);
     }
 
+    /**
+     * Set File BatchCount (OBR.1)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 1
+     *
+     * @return bool
+     *
+     */
     public function setFileBatchCount($value, int $position = 1)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set File TrailerComment (OBR.2)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 2
+     *
+     * @return bool
+     *
+     */
     public function setFileTrailerComment($value, int $position = 2)
     {
         return $this->setField($position, $value);
@@ -29,11 +47,27 @@ class FTS extends Segment
 
     // -------------------- Getter Methods ------------------------------
 
+    /**
+     * Get File BatchCount (OBR.1)
+     *
+     * @param int $position Defaults to 1
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getFileBatchCount(int $position = 1)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get File TrailerComment (OBR.2)
+     *
+     * @param int $position Defaults to 2
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getFileTrailerComment(int $position = 2)
     {
         return $this->getField($position);

--- a/src/HL7/Segments/GT1.php
+++ b/src/HL7/Segments/GT1.php
@@ -45,36 +45,99 @@ class GT1 extends Segment
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Guarantor Number (OBR.2)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 2
+     *
+     * @return bool
+     *
+     */
     public function setGuarantorNumber($value, int $position = 2)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Guarantor Name (OBR.3)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 3
+     *
+     * @return bool
+     *
+     */
     public function setGuarantorName($value, int $position = 3)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Guarantor SpouseName (OBR.4)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 4
+     *
+     * @return bool
+     *
+     */
     public function setGuarantorSpouseName($value, int $position = 4)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Guarantor Address (OBR.5)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 5
+     *
+     * @return bool
+     *
+     */
     public function setGuarantorAddress($value, int $position = 5)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Guarantor HomePhone (OBR.6)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 6
+     *
+     * @return bool
+     *
+     */
     public function setGuarantorHomePhone($value, int $position = 6)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Guarantor BusinessPhone (OBR.7)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 7
+     *
+     * @return bool
+     *
+     */
     public function setGuarantorBusinessPhone($value, int $position = 7)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Guarantor DateOfBirth (OBR.8)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 8
+     *
+     * @return bool
+     *
+     */
     public function setGuarantorDateOfBirth($value, int $position = 8)
     {
         return $this->setField($position, $value);
@@ -89,526 +152,1414 @@ class GT1 extends Segment
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Guarantor Type (OBR.10)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 10
+     *
+     * @return bool
+     *
+     */
     public function setGuarantorType($value, int $position = 10)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Guarantor Relationship (OBR.11)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 11
+     *
+     * @return bool
+     *
+     */
     public function setGuarantorRelationship($value, int $position = 11)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Guarantor SSN (OBR.12)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 12
+     *
+     * @return bool
+     *
+     */
     public function setGuarantorSSN($value, int $position = 12)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Guarantor BeginDate (OBR.13)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 13
+     *
+     * @return bool
+     *
+     */
     public function setGuarantorBeginDate($value, int $position = 13)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Guarantor EndDate (OBR.14)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 14
+     *
+     * @return bool
+     *
+     */
     public function setGuarantorEndDate($value, int $position = 14)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Guarantor Priority (OBR.15)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 15
+     *
+     * @return bool
+     *
+     */
     public function setGuarantorPriority($value, int $position = 15)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Guarantor EmployerName (OBR.16)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 16
+     *
+     * @return bool
+     *
+     */
     public function setGuarantorEmployerName($value, int $position = 16)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Guarantor EmployerAddress (OBR.17)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 17
+     *
+     * @return bool
+     *
+     */
     public function setGuarantorEmployerAddress($value, int $position = 17)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Guarantor EmployerPhone (OBR.18)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 18
+     *
+     * @return bool
+     *
+     */
     public function setGuarantorEmployerPhone($value, int $position = 18)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Guarantor EmployeeID (OBR.19)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 19
+     *
+     * @return bool
+     *
+     */
     public function setGuarantorEmployeeID($value, int $position = 19)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Guarantor EmploymentStatus (OBR.20)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 20
+     *
+     * @return bool
+     *
+     */
     public function setGuarantorEmploymentStatus($value, int $position = 20)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Guarantor OrganizationName (OBR.21)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 21
+     *
+     * @return bool
+     *
+     */
     public function setGuarantorOrganizationName($value, int $position = 21)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Guarantor BillingHoldFlag (OBR.22)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 22
+     *
+     * @return bool
+     *
+     */
     public function setGuarantorBillingHoldFlag($value, int $position = 22)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Guarantor CreditRatingCode (OBR.23)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 23
+     *
+     * @return bool
+     *
+     */
     public function setGuarantorCreditRatingCode($value, int $position = 23)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Guarantor DeathDateAndTime (OBR.24)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 24
+     *
+     * @return bool
+     *
+     */
     public function setGuarantorDeathDateAndTime($value, int $position = 24)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Guarantor DeathFlag (OBR.25)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 25
+     *
+     * @return bool
+     *
+     */
     public function setGuarantorDeathFlag($value, int $position = 25)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Guarantor ChargeAdjustmentCode (OBR.26)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 26
+     *
+     * @return bool
+     *
+     */
     public function setGuarantorChargeAdjustmentCode($value, int $position = 26)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Guarantor AnnualIncome (OBR.27)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 27
+     *
+     * @return bool
+     *
+     */
     public function setGuarantorAnnualIncome($value, int $position = 27)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Guarantor HouseholdSize (OBR.28)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 28
+     *
+     * @return bool
+     *
+     */
     public function setGuarantorHouseholdSize($value, int $position = 28)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Guarantor EmployerID (OBR.29)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 29
+     *
+     * @return bool
+     *
+     */
     public function setGuarantorEmployerID($value, int $position = 29)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Guarantor MaritalStatusCode (OBR.30)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 30
+     *
+     * @return bool
+     *
+     */
     public function setGuarantorMaritalStatusCode($value, int $position = 30)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Guarantor HireEffectiveDate (OBR.31)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 31
+     *
+     * @return bool
+     *
+     */
     public function setGuarantorHireEffectiveDate($value, int $position = 31)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Employment StopDate (OBR.32)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 32
+     *
+     * @return bool
+     *
+     */
     public function setEmploymentStopDate($value, int $position = 32)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Living Dependency (OBR.33)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 33
+     *
+     * @return bool
+     *
+     */
     public function setLivingDependency($value, int $position = 33)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Ambulatory Status (OBR.34)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 34
+     *
+     * @return bool
+     *
+     */
     public function setAmbulatoryStatus($value, int $position = 34)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Citizenship (OBR.35)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 35
+     *
+     * @return bool
+     *
+     */
     public function setCitizenship($value, int $position = 35)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Primary Language (OBR.36)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 36
+     *
+     * @return bool
+     *
+     */
     public function setPrimaryLanguage($value, int $position = 36)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Living Arrangement (OBR.37)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 37
+     *
+     * @return bool
+     *
+     */
     public function setLivingArrangement($value, int $position = 37)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Publicity Code (OBR.38)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 38
+     *
+     * @return bool
+     *
+     */
     public function setPublicityCode($value, int $position = 38)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Protection Indicator (OBR.39)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 39
+     *
+     * @return bool
+     *
+     */
     public function setProtectionIndicator($value, int $position = 39)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Student Indicator (OBR.40)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 40
+     *
+     * @return bool
+     *
+     */
     public function setStudentIndicator($value, int $position = 40)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Religion (OBR.41)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 41
+     *
+     * @return bool
+     *
+     */
     public function setReligion($value, int $position = 41)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Mother MaidenName (OBR.42)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 42
+     *
+     * @return bool
+     *
+     */
     public function setMotherMaidenName($value, int $position = 42)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Nationality (OBR.43)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 43
+     *
+     * @return bool
+     *
+     */
     public function setNationality($value, int $position = 43)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Ethnic Group (OBR.44)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 44
+     *
+     * @return bool
+     *
+     */
     public function setEthnicGroup($value, int $position = 44)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Contact PersonsName (OBR.45)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 45
+     *
+     * @return bool
+     *
+     */
     public function setContactPersonsName($value, int $position = 45)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Contact PersonsPhone (OBR.46)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 46
+     *
+     * @return bool
+     *
+     */
     public function setContactPersonsPhone($value, int $position = 46)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Contact Reason (OBR.47)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 47
+     *
+     * @return bool
+     *
+     */
     public function setContactReason($value, int $position = 47)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Contact Relationship (OBR.48)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 48
+     *
+     * @return bool
+     *
+     */
     public function setContactRelationship($value, int $position = 48)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Job Title (OBR.49)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 49
+     *
+     * @return bool
+     *
+     */
     public function setJobTitle($value, int $position = 49)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Job Class (OBR.50)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 50
+     *
+     * @return bool
+     *
+     */
     public function setJobClass($value, int $position = 50)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Guarantor EmployersOrganizationName (OBR.51)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 51
+     *
+     * @return bool
+     *
+     */
     public function setGuarantorEmployersOrganizationName($value, int $position = 51)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Handicap (OBR.52)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 52
+     *
+     * @return bool
+     *
+     */
     public function setHandicap($value, int $position = 52)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Job Status (OBR.53)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 53
+     *
+     * @return bool
+     *
+     */
     public function setJobStatus($value, int $position = 53)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Guarantor FinancialClass (OBR.54)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 54
+     *
+     * @return bool
+     *
+     */
     public function setGuarantorFinancialClass($value, int $position = 54)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Guarantor Race (OBR.55)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 55
+     *
+     * @return bool
+     *
+     */
     public function setGuarantorRace($value, int $position = 55)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Guarantor BirthPlace (OBR.56)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 56
+     *
+     * @return bool
+     *
+     */
     public function setGuarantorBirthPlace($value, int $position = 56)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Vip Indicator (OBR.57)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 57
+     *
+     * @return bool
+     *
+     */
     public function setVipIndicator($value, int $position = 57)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Get ID (OBR.1)
+     *
+     * @param int $position Defaults to 1
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getID(int $position = 1)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Guarantor Number (OBR.2)
+     *
+     * @param int $position Defaults to 2
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getGuarantorNumber(int $position = 2)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Guarantor Name (OBR.3)
+     *
+     * @param int $position Defaults to 3
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getGuarantorName(int $position = 3)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Guarantor SpouseName (OBR.4)
+     *
+     * @param int $position Defaults to 4
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getGuarantorSpouseName(int $position = 4)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Guarantor Address (OBR.5)
+     *
+     * @param int $position Defaults to 5
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getGuarantorAddress(int $position = 5)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Guarantor HomePhone (OBR.6)
+     *
+     * @param int $position Defaults to 6
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getGuarantorHomePhone(int $position = 6)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Guarantor BusinessPhone (OBR.7)
+     *
+     * @param int $position Defaults to 7
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getGuarantorBusinessPhone(int $position = 7)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Guarantor DateOfBirth (OBR.8)
+     *
+     * @param int $position Defaults to 8
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getGuarantorDateOfBirth(int $position = 8)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Guarantor Sex (OBR.9)
+     *
+     * @param int $position Defaults to 9
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getGuarantorSex(int $position = 9)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Guarantor Type (OBR.10)
+     *
+     * @param int $position Defaults to 10
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getGuarantorType(int $position = 10)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Guarantor Relationship (OBR.11)
+     *
+     * @param int $position Defaults to 11
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getGuarantorRelationship(int $position = 11)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Guarantor SSN (OBR.12)
+     *
+     * @param int $position Defaults to 12
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getGuarantorSSN(int $position = 12)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Guarantor BeginDate (OBR.13)
+     *
+     * @param int $position Defaults to 13
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getGuarantorBeginDate(int $position = 13)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Guarantor EndDate (OBR.14)
+     *
+     * @param int $position Defaults to 14
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getGuarantorEndDate(int $position = 14)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Guarantor Priority (OBR.15)
+     *
+     * @param int $position Defaults to 15
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getGuarantorPriority(int $position = 15)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Guarantor EmployerName (OBR.16)
+     *
+     * @param int $position Defaults to 16
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getGuarantorEmployerName(int $position = 16)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Guarantor EmployerAddress (OBR.17)
+     *
+     * @param int $position Defaults to 17
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getGuarantorEmployerAddress(int $position = 17)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Guarantor EmployerPhone (OBR.18)
+     *
+     * @param int $position Defaults to 18
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getGuarantorEmployerPhone(int $position = 18)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Guarantor EmployeeID (OBR.19)
+     *
+     * @param int $position Defaults to 19
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getGuarantorEmployeeID(int $position = 19)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Guarantor EmploymentStatus (OBR.20)
+     *
+     * @param int $position Defaults to 20
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getGuarantorEmploymentStatus(int $position = 20)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Guarantor OrganizationName (OBR.21)
+     *
+     * @param int $position Defaults to 21
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getGuarantorOrganizationName(int $position = 21)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Guarantor BillingHoldFlag (OBR.22)
+     *
+     * @param int $position Defaults to 22
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getGuarantorBillingHoldFlag(int $position = 22)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Guarantor CreditRatingCode (OBR.23)
+     *
+     * @param int $position Defaults to 23
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getGuarantorCreditRatingCode(int $position = 23)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Guarantor DeathDateAndTime (OBR.24)
+     *
+     * @param int $position Defaults to 24
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getGuarantorDeathDateAndTime(int $position = 24)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Guarantor DeathFlag (OBR.25)
+     *
+     * @param int $position Defaults to 25
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getGuarantorDeathFlag(int $position = 25)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Guarantor ChargeAdjustmentCode (OBR.26)
+     *
+     * @param int $position Defaults to 26
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getGuarantorChargeAdjustmentCode(int $position = 26)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Guarantor AnnualIncome (OBR.27)
+     *
+     * @param int $position Defaults to 27
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getGuarantorAnnualIncome(int $position = 27)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Guarantor HouseholdSize (OBR.28)
+     *
+     * @param int $position Defaults to 28
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getGuarantorHouseholdSize(int $position = 28)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Guarantor EmployerID (OBR.29)
+     *
+     * @param int $position Defaults to 29
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getGuarantorEmployerID(int $position = 29)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Guarantor MaritalStatusCode (OBR.30)
+     *
+     * @param int $position Defaults to 30
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getGuarantorMaritalStatusCode(int $position = 30)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Guarantor HireEffectiveDate (OBR.31)
+     *
+     * @param int $position Defaults to 31
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getGuarantorHireEffectiveDate(int $position = 31)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Employment StopDate (OBR.32)
+     *
+     * @param int $position Defaults to 32
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getEmploymentStopDate(int $position = 32)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Living Dependency (OBR.33)
+     *
+     * @param int $position Defaults to 33
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getLivingDependency(int $position = 33)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Ambulatory Status (OBR.34)
+     *
+     * @param int $position Defaults to 34
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getAmbulatoryStatus(int $position = 34)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Citizenship (OBR.35)
+     *
+     * @param int $position Defaults to 35
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getCitizenship(int $position = 35)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Primary Language (OBR.36)
+     *
+     * @param int $position Defaults to 36
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getPrimaryLanguage(int $position = 36)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Living Arrangement (OBR.37)
+     *
+     * @param int $position Defaults to 37
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getLivingArrangement(int $position = 37)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Publicity Code (OBR.38)
+     *
+     * @param int $position Defaults to 38
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getPublicityCode(int $position = 38)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Protection Indicator (OBR.39)
+     *
+     * @param int $position Defaults to 39
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getProtectionIndicator(int $position = 39)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Student Indicator (OBR.40)
+     *
+     * @param int $position Defaults to 40
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getStudentIndicator(int $position = 40)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Religion (OBR.41)
+     *
+     * @param int $position Defaults to 41
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getReligion(int $position = 41)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Mother MaidenName (OBR.42)
+     *
+     * @param int $position Defaults to 42
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getMotherMaidenName(int $position = 42)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Nationality (OBR.43)
+     *
+     * @param int $position Defaults to 43
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getNationality(int $position = 43)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Ethnic Group (OBR.44)
+     *
+     * @param int $position Defaults to 44
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getEthnicGroup(int $position = 44)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Contact PersonsName (OBR.45)
+     *
+     * @param int $position Defaults to 45
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getContactPersonsName(int $position = 45)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Contact PersonsPhone (OBR.46)
+     *
+     * @param int $position Defaults to 46
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getContactPersonsPhone(int $position = 46)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Contact Reason (OBR.47)
+     *
+     * @param int $position Defaults to 47
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getContactReason(int $position = 47)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Contact Relationship (OBR.48)
+     *
+     * @param int $position Defaults to 48
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getContactRelationship(int $position = 48)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Job Title (OBR.49)
+     *
+     * @param int $position Defaults to 49
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getJobTitle(int $position = 49)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Job Class (OBR.50)
+     *
+     * @param int $position Defaults to 50
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getJobClass(int $position = 50)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Guarantor EmployersOrganizationName (OBR.51)
+     *
+     * @param int $position Defaults to 51
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getGuarantorEmployersOrganizationName(int $position = 51)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Handicap (OBR.52)
+     *
+     * @param int $position Defaults to 52
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getHandicap(int $position = 52)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Job Status (OBR.53)
+     *
+     * @param int $position Defaults to 53
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getJobStatus(int $position = 53)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Guarantor FinancialClass (OBR.54)
+     *
+     * @param int $position Defaults to 54
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getGuarantorFinancialClass(int $position = 54)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Guarantor Race (OBR.55)
+     *
+     * @param int $position Defaults to 55
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getGuarantorRace(int $position = 55)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Guarantor BirthPlace (OBR.56)
+     *
+     * @param int $position Defaults to 56
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getGuarantorBirthPlace(int $position = 56)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Vip Indicator (OBR.57)
+     *
+     * @param int $position Defaults to 57
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getVipIndicator(int $position = 57)
     {
         return $this->getField($position);

--- a/src/HL7/Segments/IN1.php
+++ b/src/HL7/Segments/IN1.php
@@ -44,486 +44,1310 @@ class IN1 extends Segment
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Insurance PlanID (OBR.2)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 2
+     *
+     * @return bool
+     *
+     */
     public function setInsurancePlanID($value, int $position = 2)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Insurance CompanyID (OBR.3)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 3
+     *
+     * @return bool
+     *
+     */
     public function setInsuranceCompanyID($value, int $position = 3)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Insurance CompanyName (OBR.4)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 4
+     *
+     * @return bool
+     *
+     */
     public function setInsuranceCompanyName($value, int $position = 4)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Insurance CompanyAddress (OBR.5)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 5
+     *
+     * @return bool
+     *
+     */
     public function setInsuranceCompanyAddress($value, int $position = 5)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Insurance CoContactPerson (OBR.6)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 6
+     *
+     * @return bool
+     *
+     */
     public function setInsuranceCoContactPerson($value, int $position = 6)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Insurance CoPhoneNumber (OBR.7)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 7
+     *
+     * @return bool
+     *
+     */
     public function setInsuranceCoPhoneNumber($value, int $position = 7)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Group Number (OBR.8)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 8
+     *
+     * @return bool
+     *
+     */
     public function setGroupNumber($value, int $position = 8)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Group Name (OBR.9)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 9
+     *
+     * @return bool
+     *
+     */
     public function setGroupName($value, int $position = 9)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Insureds GroupEmpID (OBR.10)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 10
+     *
+     * @return bool
+     *
+     */
     public function setInsuredsGroupEmpID($value, int $position = 10)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Insureds GroupEmpName (OBR.11)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 11
+     *
+     * @return bool
+     *
+     */
     public function setInsuredsGroupEmpName($value, int $position = 11)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Plan EffectiveDate (OBR.12)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 12
+     *
+     * @return bool
+     *
+     */
     public function setPlanEffectiveDate($value, int $position = 12)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Plan ExpirationDate (OBR.13)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 13
+     *
+     * @return bool
+     *
+     */
     public function setPlanExpirationDate($value, int $position = 13)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Authorization Information (OBR.14)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 14
+     *
+     * @return bool
+     *
+     */
     public function setAuthorizationInformation($value, int $position = 14)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Plan Type (OBR.15)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 15
+     *
+     * @return bool
+     *
+     */
     public function setPlanType($value, int $position = 15)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Name OfInsured (OBR.16)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 16
+     *
+     * @return bool
+     *
+     */
     public function setNameOfInsured($value, int $position = 16)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Insureds RelationshipToPatient (OBR.17)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 17
+     *
+     * @return bool
+     *
+     */
     public function setInsuredsRelationshipToPatient($value, int $position = 17)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Insureds DateOfBirth (OBR.18)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 18
+     *
+     * @return bool
+     *
+     */
     public function setInsuredsDateOfBirth($value, int $position = 18)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Insureds Address (OBR.19)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 19
+     *
+     * @return bool
+     *
+     */
     public function setInsuredsAddress($value, int $position = 19)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Assignment OfBenefits (OBR.20)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 20
+     *
+     * @return bool
+     *
+     */
     public function setAssignmentOfBenefits($value, int $position = 20)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Coordination OfBenefits (OBR.21)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 21
+     *
+     * @return bool
+     *
+     */
     public function setCoordinationOfBenefits($value, int $position = 21)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Coord OfBenPriority (OBR.22)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 22
+     *
+     * @return bool
+     *
+     */
     public function setCoordOfBenPriority($value, int $position = 22)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Notice OfAdmissionFlag (OBR.23)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 23
+     *
+     * @return bool
+     *
+     */
     public function setNoticeOfAdmissionFlag($value, int $position = 23)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Notice OfAdmissionDate (OBR.24)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 24
+     *
+     * @return bool
+     *
+     */
     public function setNoticeOfAdmissionDate($value, int $position = 24)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Report OfEligibilityFlag (OBR.25)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 25
+     *
+     * @return bool
+     *
+     */
     public function setReportOfEligibilityFlag($value, int $position = 25)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Report OfEligibilityDate (OBR.26)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 26
+     *
+     * @return bool
+     *
+     */
     public function setReportOfEligibilityDate($value, int $position = 26)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Release InformationCode (OBR.27)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 27
+     *
+     * @return bool
+     *
+     */
     public function setReleaseInformationCode($value, int $position = 27)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Pre AdmitCertPAC (OBR.28)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 28
+     *
+     * @return bool
+     *
+     */
     public function setPreAdmitCertPAC($value, int $position = 28)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Verification DateTime (OBR.29)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 29
+     *
+     * @return bool
+     *
+     */
     public function setVerificationDateTime($value, int $position = 29)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Verification By (OBR.30)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 30
+     *
+     * @return bool
+     *
+     */
     public function setVerificationBy($value, int $position = 30)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Type OfAgreementCode (OBR.31)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 31
+     *
+     * @return bool
+     *
+     */
     public function setTypeOfAgreementCode($value, int $position = 31)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Billing Status (OBR.32)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 32
+     *
+     * @return bool
+     *
+     */
     public function setBillingStatus($value, int $position = 32)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Lifetime ReserveDays (OBR.33)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 33
+     *
+     * @return bool
+     *
+     */
     public function setLifetimeReserveDays($value, int $position = 33)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Delay BeforeLRDay (OBR.34)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 34
+     *
+     * @return bool
+     *
+     */
     public function setDelayBeforeLRDay($value, int $position = 34)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Company PlanCode (OBR.35)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 35
+     *
+     * @return bool
+     *
+     */
     public function setCompanyPlanCode($value, int $position = 35)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Policy Number (OBR.36)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 36
+     *
+     * @return bool
+     *
+     */
     public function setPolicyNumber($value, int $position = 36)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Policy Deductible (OBR.37)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 37
+     *
+     * @return bool
+     *
+     */
     public function setPolicyDeductible($value, int $position = 37)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Policy LimitAmount (OBR.38)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 38
+     *
+     * @return bool
+     *
+     */
     public function setPolicyLimitAmount($value, int $position = 38)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Policy LimitDays (OBR.39)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 39
+     *
+     * @return bool
+     *
+     */
     public function setPolicyLimitDays($value, int $position = 39)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Room RateSemiPrivate (OBR.40)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 40
+     *
+     * @return bool
+     *
+     */
     public function setRoomRateSemiPrivate($value, int $position = 40)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Room RatePrivate (OBR.41)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 41
+     *
+     * @return bool
+     *
+     */
     public function setRoomRatePrivate($value, int $position = 41)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Insureds EmploymentStatus (OBR.42)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 42
+     *
+     * @return bool
+     *
+     */
     public function setInsuredsEmploymentStatus($value, int $position = 42)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Insureds Sex (OBR.43)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 43
+     *
+     * @return bool
+     *
+     */
     public function setInsuredsSex($value, int $position = 43)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Insureds EmployersAddress (OBR.44)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 44
+     *
+     * @return bool
+     *
+     */
     public function setInsuredsEmployersAddress($value, int $position = 44)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Verification Status (OBR.45)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 45
+     *
+     * @return bool
+     *
+     */
     public function setVerificationStatus($value, int $position = 45)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Prior InsurancePlanID (OBR.46)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 46
+     *
+     * @return bool
+     *
+     */
     public function setPriorInsurancePlanID($value, int $position = 46)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Coverage Type (OBR.47)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 47
+     *
+     * @return bool
+     *
+     */
     public function setCoverageType($value, int $position = 47)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Handicap (OBR.48)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 48
+     *
+     * @return bool
+     *
+     */
     public function setHandicap($value, int $position = 48)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Insureds IDNumber (OBR.49)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 49
+     *
+     * @return bool
+     *
+     */
     public function setInsuredsIDNumber($value, int $position = 49)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Get ID (OBR.1)
+     *
+     * @param int $position Defaults to 1
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getID(int $position = 1)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Insurance PlanID (OBR.2)
+     *
+     * @param int $position Defaults to 2
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getInsurancePlanID(int $position = 2)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Insurance CompanyID (OBR.3)
+     *
+     * @param int $position Defaults to 3
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getInsuranceCompanyID(int $position = 3)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Insurance CompanyName (OBR.4)
+     *
+     * @param int $position Defaults to 4
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getInsuranceCompanyName(int $position = 4)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Insurance CompanyAddress (OBR.5)
+     *
+     * @param int $position Defaults to 5
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getInsuranceCompanyAddress(int $position = 5)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Insurance CoContactPerson (OBR.6)
+     *
+     * @param int $position Defaults to 6
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getInsuranceCoContactPerson(int $position = 6)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Insurance CoPhoneNumber (OBR.7)
+     *
+     * @param int $position Defaults to 7
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getInsuranceCoPhoneNumber(int $position = 7)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Group Number (OBR.8)
+     *
+     * @param int $position Defaults to 8
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getGroupNumber(int $position = 8)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Group Name (OBR.9)
+     *
+     * @param int $position Defaults to 9
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getGroupName(int $position = 9)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Insureds GroupEmpID (OBR.10)
+     *
+     * @param int $position Defaults to 10
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getInsuredsGroupEmpID(int $position = 10)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Insureds GroupEmpName (OBR.11)
+     *
+     * @param int $position Defaults to 11
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getInsuredsGroupEmpName(int $position = 11)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Plan EffectiveDate (OBR.12)
+     *
+     * @param int $position Defaults to 12
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getPlanEffectiveDate(int $position = 12)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Plan ExpirationDate (OBR.13)
+     *
+     * @param int $position Defaults to 13
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getPlanExpirationDate(int $position = 13)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Authorization Information (OBR.14)
+     *
+     * @param int $position Defaults to 14
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getAuthorizationInformation(int $position = 14)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Plan Type (OBR.15)
+     *
+     * @param int $position Defaults to 15
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getPlanType(int $position = 15)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Name OfInsured (OBR.16)
+     *
+     * @param int $position Defaults to 16
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getNameOfInsured(int $position = 16)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Insureds RelationshipToPatient (OBR.17)
+     *
+     * @param int $position Defaults to 17
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getInsuredsRelationshipToPatient(int $position = 17)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Insureds DateOfBirth (OBR.18)
+     *
+     * @param int $position Defaults to 18
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getInsuredsDateOfBirth(int $position = 18)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Insureds Address (OBR.19)
+     *
+     * @param int $position Defaults to 19
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getInsuredsAddress(int $position = 19)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Assignment OfBenefits (OBR.20)
+     *
+     * @param int $position Defaults to 20
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getAssignmentOfBenefits(int $position = 20)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Coordination OfBenefits (OBR.21)
+     *
+     * @param int $position Defaults to 21
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getCoordinationOfBenefits(int $position = 21)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Coord OfBenPriority (OBR.22)
+     *
+     * @param int $position Defaults to 22
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getCoordOfBenPriority(int $position = 22)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Notice OfAdmissionFlag (OBR.23)
+     *
+     * @param int $position Defaults to 23
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getNoticeOfAdmissionFlag(int $position = 23)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Notice OfAdmissionDate (OBR.24)
+     *
+     * @param int $position Defaults to 24
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getNoticeOfAdmissionDate(int $position = 24)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Report OfEligibilityFlag (OBR.25)
+     *
+     * @param int $position Defaults to 25
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getReportOfEligibilityFlag(int $position = 25)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Report OfEligibilityDate (OBR.26)
+     *
+     * @param int $position Defaults to 26
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getReportOfEligibilityDate(int $position = 26)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Release InformationCode (OBR.27)
+     *
+     * @param int $position Defaults to 27
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getReleaseInformationCode(int $position = 27)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Pre AdmitCertPAC (OBR.28)
+     *
+     * @param int $position Defaults to 28
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getPreAdmitCertPAC(int $position = 28)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Verification DateTime (OBR.29)
+     *
+     * @param int $position Defaults to 29
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getVerificationDateTime(int $position = 29)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Verification By (OBR.30)
+     *
+     * @param int $position Defaults to 30
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getVerificationBy(int $position = 30)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Type OfAgreementCode (OBR.31)
+     *
+     * @param int $position Defaults to 31
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getTypeOfAgreementCode(int $position = 31)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Billing Status (OBR.32)
+     *
+     * @param int $position Defaults to 32
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getBillingStatus(int $position = 32)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Lifetime ReserveDays (OBR.33)
+     *
+     * @param int $position Defaults to 33
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getLifetimeReserveDays(int $position = 33)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Delay BeforeLRDay (OBR.34)
+     *
+     * @param int $position Defaults to 34
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getDelayBeforeLRDay(int $position = 34)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Company PlanCode (OBR.35)
+     *
+     * @param int $position Defaults to 35
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getCompanyPlanCode(int $position = 35)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Policy Number (OBR.36)
+     *
+     * @param int $position Defaults to 36
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getPolicyNumber(int $position = 36)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Policy Deductible (OBR.37)
+     *
+     * @param int $position Defaults to 37
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getPolicyDeductible(int $position = 37)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Policy LimitAmount (OBR.38)
+     *
+     * @param int $position Defaults to 38
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getPolicyLimitAmount(int $position = 38)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Policy LimitDays (OBR.39)
+     *
+     * @param int $position Defaults to 39
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getPolicyLimitDays(int $position = 39)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Room RateSemiPrivate (OBR.40)
+     *
+     * @param int $position Defaults to 40
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getRoomRateSemiPrivate(int $position = 40)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Room RatePrivate (OBR.41)
+     *
+     * @param int $position Defaults to 41
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getRoomRatePrivate(int $position = 41)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Insureds EmploymentStatus (OBR.42)
+     *
+     * @param int $position Defaults to 42
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getInsuredsEmploymentStatus(int $position = 42)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Insureds Sex (OBR.43)
+     *
+     * @param int $position Defaults to 43
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getInsuredsSex(int $position = 43)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Insureds EmployersAddress (OBR.44)
+     *
+     * @param int $position Defaults to 44
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getInsuredsEmployersAddress(int $position = 44)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Verification Status (OBR.45)
+     *
+     * @param int $position Defaults to 45
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getVerificationStatus(int $position = 45)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Prior InsurancePlanID (OBR.46)
+     *
+     * @param int $position Defaults to 46
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getPriorInsurancePlanID(int $position = 46)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Coverage Type (OBR.47)
+     *
+     * @param int $position Defaults to 47
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getCoverageType(int $position = 47)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Handicap (OBR.48)
+     *
+     * @param int $position Defaults to 48
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getHandicap(int $position = 48)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Insureds IDNumber (OBR.49)
+     *
+     * @param int $position Defaults to 49
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getInsuredsIDNumber(int $position = 49)
     {
         return $this->getField($position);

--- a/src/HL7/Segments/IN3.php
+++ b/src/HL7/Segments/IN3.php
@@ -44,246 +44,662 @@ class IN3 extends Segment
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Certification Number (OBR.2)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 2
+     *
+     * @return bool
+     *
+     */
     public function setCertificationNumber($value, int $position = 2)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Certified By (OBR.3)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 3
+     *
+     * @return bool
+     *
+     */
     public function setCertifiedBy($value, int $position = 3)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Certification Required (OBR.4)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 4
+     *
+     * @return bool
+     *
+     */
     public function setCertificationRequired($value, int $position = 4)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Penalty (OBR.5)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 5
+     *
+     * @return bool
+     *
+     */
     public function setPenalty($value, int $position = 5)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Certification DateTime (OBR.6)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 6
+     *
+     * @return bool
+     *
+     */
     public function setCertificationDateTime($value, int $position = 6)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Certification ModifyDateTime (OBR.7)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 7
+     *
+     * @return bool
+     *
+     */
     public function setCertificationModifyDateTime($value, int $position = 7)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Operator (OBR.8)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 8
+     *
+     * @return bool
+     *
+     */
     public function setOperator($value, int $position = 8)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Certification BeginDate (OBR.9)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 9
+     *
+     * @return bool
+     *
+     */
     public function setCertificationBeginDate($value, int $position = 9)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Certification EndDate (OBR.10)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 10
+     *
+     * @return bool
+     *
+     */
     public function setCertificationEndDate($value, int $position = 10)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Days (OBR.11)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 11
+     *
+     * @return bool
+     *
+     */
     public function setDays($value, int $position = 11)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Non ConcurCodeDescription (OBR.12)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 12
+     *
+     * @return bool
+     *
+     */
     public function setNonConcurCodeDescription($value, int $position = 12)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Non ConcurEffectiveDateTime (OBR.13)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 13
+     *
+     * @return bool
+     *
+     */
     public function setNonConcurEffectiveDateTime($value, int $position = 13)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Physician Reviewer (OBR.14)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 14
+     *
+     * @return bool
+     *
+     */
     public function setPhysicianReviewer($value, int $position = 14)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Certification Contact (OBR.15)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 15
+     *
+     * @return bool
+     *
+     */
     public function setCertificationContact($value, int $position = 15)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Certification ContactPhoneNumber (OBR.16)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 16
+     *
+     * @return bool
+     *
+     */
     public function setCertificationContactPhoneNumber($value, int $position = 16)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Appeal Reason (OBR.17)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 17
+     *
+     * @return bool
+     *
+     */
     public function setAppealReason($value, int $position = 17)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Certification Agency (OBR.18)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 18
+     *
+     * @return bool
+     *
+     */
     public function setCertificationAgency($value, int $position = 18)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Certification AgencyPhoneNumber (OBR.19)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 19
+     *
+     * @return bool
+     *
+     */
     public function setCertificationAgencyPhoneNumber($value, int $position = 19)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Pre CertificationRequirement (OBR.20)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 20
+     *
+     * @return bool
+     *
+     */
     public function setPreCertificationRequirement($value, int $position = 20)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Case Manager (OBR.21)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 21
+     *
+     * @return bool
+     *
+     */
     public function setCaseManager($value, int $position = 21)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Second OpinionDate (OBR.22)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 22
+     *
+     * @return bool
+     *
+     */
     public function setSecondOpinionDate($value, int $position = 22)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Second OpinionStatus (OBR.23)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 23
+     *
+     * @return bool
+     *
+     */
     public function setSecondOpinionStatus($value, int $position = 23)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Second OpinionDocumentationReceived (OBR.24)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 24
+     *
+     * @return bool
+     *
+     */
     public function setSecondOpinionDocumentationReceived($value, int $position = 24)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Second OpinionPhysician (OBR.25)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 25
+     *
+     * @return bool
+     *
+     */
     public function setSecondOpinionPhysician($value, int $position = 25)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Get ID (OBR.1)
+     *
+     * @param int $position Defaults to 1
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getID(int $position = 1)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Certification Number (OBR.2)
+     *
+     * @param int $position Defaults to 2
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getCertificationNumber(int $position = 2)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Certified By (OBR.3)
+     *
+     * @param int $position Defaults to 3
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getCertifiedBy(int $position = 3)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Certification Required (OBR.4)
+     *
+     * @param int $position Defaults to 4
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getCertificationRequired(int $position = 4)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Penalty (OBR.5)
+     *
+     * @param int $position Defaults to 5
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getPenalty(int $position = 5)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Certification DateTime (OBR.6)
+     *
+     * @param int $position Defaults to 6
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getCertificationDateTime(int $position = 6)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Certification ModifyDateTime (OBR.7)
+     *
+     * @param int $position Defaults to 7
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getCertificationModifyDateTime(int $position = 7)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Operator (OBR.8)
+     *
+     * @param int $position Defaults to 8
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getOperator(int $position = 8)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Certification BeginDate (OBR.9)
+     *
+     * @param int $position Defaults to 9
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getCertificationBeginDate(int $position = 9)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Certification EndDate (OBR.10)
+     *
+     * @param int $position Defaults to 10
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getCertificationEndDate(int $position = 10)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Days (OBR.11)
+     *
+     * @param int $position Defaults to 11
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getDays(int $position = 11)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Non ConcurCodeDescription (OBR.12)
+     *
+     * @param int $position Defaults to 12
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getNonConcurCodeDescription(int $position = 12)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Non ConcurEffectiveDateTime (OBR.13)
+     *
+     * @param int $position Defaults to 13
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getNonConcurEffectiveDateTime(int $position = 13)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Physician Reviewer (OBR.14)
+     *
+     * @param int $position Defaults to 14
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getPhysicianReviewer(int $position = 14)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Certification Contact (OBR.15)
+     *
+     * @param int $position Defaults to 15
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getCertificationContact(int $position = 15)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Certification ContactPhoneNumber (OBR.16)
+     *
+     * @param int $position Defaults to 16
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getCertificationContactPhoneNumber(int $position = 16)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Appeal Reason (OBR.17)
+     *
+     * @param int $position Defaults to 17
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getAppealReason(int $position = 17)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Certification Agency (OBR.18)
+     *
+     * @param int $position Defaults to 18
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getCertificationAgency(int $position = 18)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Certification AgencyPhoneNumber (OBR.19)
+     *
+     * @param int $position Defaults to 19
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getCertificationAgencyPhoneNumber(int $position = 19)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Pre CertificationRequirement (OBR.20)
+     *
+     * @param int $position Defaults to 20
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getPreCertificationRequirement(int $position = 20)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Case Manager (OBR.21)
+     *
+     * @param int $position Defaults to 21
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getCaseManager(int $position = 21)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Second OpinionDate (OBR.22)
+     *
+     * @param int $position Defaults to 22
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getSecondOpinionDate(int $position = 22)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Second OpinionStatus (OBR.23)
+     *
+     * @param int $position Defaults to 23
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getSecondOpinionStatus(int $position = 23)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Second OpinionDocumentationReceived (OBR.24)
+     *
+     * @param int $position Defaults to 24
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getSecondOpinionDocumentationReceived(int $position = 24)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Second OpinionPhysician (OBR.25)
+     *
+     * @param int $position Defaults to 25
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getSecondOpinionPhysician(int $position = 25)
     {
         return $this->getField($position);

--- a/src/HL7/Segments/MRG.php
+++ b/src/HL7/Segments/MRG.php
@@ -17,71 +17,190 @@ class MRG extends Segment
         parent::__construct('MRG', $fields);
     }
 
+    /**
+     * Set Prior PatientIdentifierList (OBR.1)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 1
+     *
+     * @return bool
+     *
+     */
     public function setPriorPatientIdentifierList($value, int $position = 1): bool
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Prior AlternatePatientID (OBR.2)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 2
+     *
+     * @return bool
+     *
+     */
     public function setPriorAlternatePatientID($value, int $position = 2): bool
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Prior PatientAccountNumber (OBR.3)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 3
+     *
+     * @return bool
+     *
+     */
     public function setPriorPatientAccountNumber($value, int $position = 3): bool
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Prior PatientID (OBR.4)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 4
+     *
+     * @return bool
+     *
+     */
     public function setPriorPatientID($value, int $position = 4): bool
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Prior VisitNumber (OBR.5)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 5
+     *
+     * @return bool
+     *
+     */
     public function setPriorVisitNumber($value, int $position = 5): bool
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Prior AlternateVisitID (OBR.6)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 6
+     *
+     * @return bool
+     *
+     */
     public function setPriorAlternateVisitID($value, int $position = 6): bool
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Prior PatientName (OBR.7)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 7
+     *
+     * @return bool
+     *
+     */
     public function setPriorPatientName($value, int $position = 7): bool
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Get Prior PatientIdentifierList (OBR.1)
+     *
+     * @param int $position Defaults to 1
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getPriorPatientIdentifierList(int $position = 1)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Prior AlternatePatientID (OBR.2)
+     *
+     * @param int $position Defaults to 2
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getPriorAlternatePatientID(int $position = 2)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Prior PatientAccountNumber (OBR.3)
+     *
+     * @param int $position Defaults to 3
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getPriorPatientAccountNumber(int $position = 3)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Prior PatientID (OBR.4)
+     *
+     * @param int $position Defaults to 4
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getPriorPatientID(int $position = 4)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Prior VisitNumber (OBR.5)
+     *
+     * @param int $position Defaults to 5
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getPriorVisitNumber(int $position = 5)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Prior AlternateVisitID (OBR.6)
+     *
+     * @param int $position Defaults to 6
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getPriorAlternateVisitID(int $position = 6)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Prior PatientName (OBR.7)
+     *
+     * @param int $position Defaults to 7
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getPriorPatientName(int $position = 7)
     {
         return $this->getField($position);

--- a/src/HL7/Segments/MSA.php
+++ b/src/HL7/Segments/MSA.php
@@ -17,31 +17,85 @@ class MSA extends Segment
         parent::__construct('MSA', $fields);
     }
 
+    /**
+     * Set Acknowledgement Code (OBR.1)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 1
+     *
+     * @return bool
+     *
+     */
     public function setAcknowledgementCode($value, int $position = 1)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Message ControlID (OBR.2)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 2
+     *
+     * @return bool
+     *
+     */
     public function setMessageControlID($value, int $position = 2)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Text Message (OBR.3)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 3
+     *
+     * @return bool
+     *
+     */
     public function setTextMessage($value, int $position = 3)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Expected SequenceNumber (OBR.4)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 4
+     *
+     * @return bool
+     *
+     */
     public function setExpectedSequenceNumber($value, int $position = 4)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Delayed AcknowledgementType (OBR.5)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 5
+     *
+     * @return bool
+     *
+     */
     public function setDelayedAcknowledgementType($value, int $position = 5)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Error Condition (OBR.6)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 6
+     *
+     * @return bool
+     *
+     */
     public function setErrorCondition($value, int $position = 6)
     {
         return $this->setField($position, $value);
@@ -49,31 +103,79 @@ class MSA extends Segment
 
     // -------------------- Getter Methods ------------------------------
 
+    /**
+     * Get Acknowledgement Code (OBR.1)
+     *
+     * @param int $position Defaults to 1
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getAcknowledgementCode(int $position = 1)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Message ControlID (OBR.2)
+     *
+     * @param int $position Defaults to 2
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getMessageControlID(int $position = 2)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Text Message (OBR.3)
+     *
+     * @param int $position Defaults to 3
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getTextMessage(int $position = 3)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Expected SequenceNumber (OBR.4)
+     *
+     * @param int $position Defaults to 4
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getExpectedSequenceNumber(int $position = 4)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Delayed AcknowledgementType (OBR.5)
+     *
+     * @param int $position Defaults to 5
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getDelayedAcknowledgementType(int $position = 5)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Error Condition (OBR.6)
+     *
+     * @param int $position Defaults to 6
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getErrorCondition(int $position = 6)
     {
         return $this->getField($position);

--- a/src/HL7/Segments/MSH.php
+++ b/src/HL7/Segments/MSH.php
@@ -94,31 +94,85 @@ class MSH extends Segment
 
     // -------------------- Setter Methods ------------------------------
 
+    /**
+     * Set Sending Application (OBR.3)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 3
+     *
+     * @return bool
+     *
+     */
     public function setSendingApplication($value, int $position = 3)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Sending Facility (OBR.4)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 4
+     *
+     * @return bool
+     *
+     */
     public function setSendingFacility($value, int $position = 4)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Receiving Application (OBR.5)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 5
+     *
+     * @return bool
+     *
+     */
     public function setReceivingApplication($value, int $position = 5)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Receiving Facility (OBR.6)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 6
+     *
+     * @return bool
+     *
+     */
     public function setReceivingFacility($value, int $position = 6)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Date TimeOfMessage (OBR.7)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 7
+     *
+     * @return bool
+     *
+     */
     public function setDateTimeOfMessage($value, int $position = 7)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Security (OBR.8)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 8
+     *
+     * @return bool
+     *
+     */
     public function setSecurity($value, int $position = 8)
     {
         return $this->setField($position, $value);
@@ -142,6 +196,15 @@ class MSH extends Segment
      * If it was empty then the new value will be just ORM.
      *
      * @param string $value
+     */
+    /**
+     * Set Message Type (OBR.9)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 9
+     *
+     * @return bool
+     *
      */
     public function setMessageType($value, int $position = 9): bool
     {
@@ -171,6 +234,15 @@ class MSH extends Segment
      *
      * @param string $value
      */
+    /**
+     * Set Trigger Event (OBR.9)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 9
+     *
+     * @return bool
+     *
+     */
     public function setTriggerEvent($value, int $position = 9): bool
     {
         $typeField = $this->getField($position);
@@ -182,51 +254,141 @@ class MSH extends Segment
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Message ControlId (OBR.10)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 10
+     *
+     * @return bool
+     *
+     */
     public function setMessageControlId($value, int $position = 10)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Processing Id (OBR.11)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 11
+     *
+     * @return bool
+     *
+     */
     public function setProcessingId($value, int $position = 11)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Version Id (OBR.12)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 12
+     *
+     * @return bool
+     *
+     */
     public function setVersionId($value, int $position = 12)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Sequence Number (OBR.13)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 13
+     *
+     * @return bool
+     *
+     */
     public function setSequenceNumber($value, int $position = 13)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Continuation Pointer (OBR.14)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 14
+     *
+     * @return bool
+     *
+     */
     public function setContinuationPointer($value, int $position = 14)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Accept AcknowledgementType (OBR.15)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 15
+     *
+     * @return bool
+     *
+     */
     public function setAcceptAcknowledgementType($value, int $position = 15)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Application AcknowledgementType (OBR.16)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 16
+     *
+     * @return bool
+     *
+     */
     public function setApplicationAcknowledgementType($value, int $position = 16)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Country Code (OBR.17)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 17
+     *
+     * @return bool
+     *
+     */
     public function setCountryCode($value, int $position = 17)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Character Set (OBR.18)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 18
+     *
+     * @return bool
+     *
+     */
     public function setCharacterSet($value, int $position = 18)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Principal Language (OBR.19)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 19
+     *
+     * @return bool
+     *
+     */
     public function setPrincipalLanguage($value, int $position = 19)
     {
         return $this->setField($position, $value);
@@ -234,26 +396,66 @@ class MSH extends Segment
 
     // -------------------- Getter Methods ------------------------------
 
+    /**
+     * Get Sending Application (OBR.3)
+     *
+     * @param int $position Defaults to 3
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getSendingApplication(int $position = 3)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Sending Facility (OBR.4)
+     *
+     * @param int $position Defaults to 4
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getSendingFacility(int $position = 4)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Receiving Application (OBR.5)
+     *
+     * @param int $position Defaults to 5
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getReceivingApplication(int $position = 5)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Receiving Facility (OBR.6)
+     *
+     * @param int $position Defaults to 6
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getReceivingFacility(int $position = 6)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Date TimeOfMessage (OBR.7)
+     *
+     * @param int $position Defaults to 7
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getDateTimeOfMessage(int $position = 7)
     {
         return $this->getField($position);
@@ -261,6 +463,14 @@ class MSH extends Segment
 
     /**
      * ORM / ORU etc.
+     */
+    /**
+     * Get Message Type (OBR.9)
+     *
+     * @param int $position Defaults to 9
+     *
+     * @return array|string|int|null
+     *
      */
     public function getMessageType(int $position = 9): string
     {
@@ -271,6 +481,14 @@ class MSH extends Segment
         return (string) $typeField;
     }
 
+    /**
+     * Get Trigger Event (OBR.9)
+     *
+     * @param int $position Defaults to 9
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getTriggerEvent(int $position = 9): string|bool
     {
         $triggerField = $this->getField($position);
@@ -280,11 +498,27 @@ class MSH extends Segment
         return false;
     }
 
+    /**
+     * Get Message ControlId (OBR.10)
+     *
+     * @param int $position Defaults to 10
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getMessageControlId(int $position = 10): string
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Processing Id (OBR.11)
+     *
+     * @param int $position Defaults to 11
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getProcessingId(int $position = 11)
     {
         return $this->getField($position);
@@ -292,6 +526,14 @@ class MSH extends Segment
 
     /**
      * Get HL7 version, e.g. 2.1, 2.3, 3.0 etc.
+     */
+    /**
+     * Get Version Id (OBR.12)
+     *
+     * @param int $position Defaults to 12
+     *
+     * @return array|string|int|null
+     *
      */
     public function getVersionId(int $position = 12): string|array
     {

--- a/src/HL7/Segments/MSH.php
+++ b/src/HL7/Segments/MSH.php
@@ -180,7 +180,11 @@ class MSH extends Segment
 
     /**
      *
-     * Sets message type to MSH segment.
+     *
+     * @param string $value
+     */
+    /**
+     * Sets message type to MSH segment. (OBR.9)
      *
      * If trigger event is already set, then it is preserved
      *
@@ -194,11 +198,6 @@ class MSH extends Segment
      *
      * Then the new field value will be ORM^R01.
      * If it was empty then the new value will be just ORM.
-     *
-     * @param string $value
-     */
-    /**
-     * Set Message Type (OBR.9)
      *
      * @param string|int|array|null $value
      * @param int $position Defaults to 9
@@ -216,8 +215,7 @@ class MSH extends Segment
     }
 
     /**
-     *
-     * Sets trigger event to MSH segment.
+     * Sets trigger event to MSH segment. (OBR.9)
      *
      * If meessage type is already set, then it is preserved
      *
@@ -231,11 +229,6 @@ class MSH extends Segment
      *
      * Then the new field value will be ORU^R30.
      * If trigger event was not set then it will set the new value.
-     *
-     * @param string $value
-     */
-    /**
-     * Set Trigger Event (OBR.9)
      *
      * @param string|int|array|null $value
      * @param int $position Defaults to 9

--- a/src/HL7/Segments/NK1.php
+++ b/src/HL7/Segments/NK1.php
@@ -47,386 +47,1040 @@ class NK1 extends Segment
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set NKName (OBR.2)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 2
+     *
+     * @return bool
+     *
+     */
     public function setNKName($value, int $position = 2)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Relationship (OBR.3)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 3
+     *
+     * @return bool
+     *
+     */
     public function setRelationship($value, int $position = 3)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Address (OBR.4)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 4
+     *
+     * @return bool
+     *
+     */
     public function setAddress($value, int $position = 4)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Phone Number (OBR.5)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 5
+     *
+     * @return bool
+     *
+     */
     public function setPhoneNumber($value, int $position = 5)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Business PhoneNumber (OBR.6)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 6
+     *
+     * @return bool
+     *
+     */
     public function setBusinessPhoneNumber($value, int $position = 6)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Contact Role (OBR.7)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 7
+     *
+     * @return bool
+     *
+     */
     public function setContactRole($value, int $position = 7)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Start Date (OBR.8)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 8
+     *
+     * @return bool
+     *
+     */
     public function setStartDate($value, int $position = 8)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set End Date (OBR.9)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 9
+     *
+     * @return bool
+     *
+     */
     public function setEndDate($value, int $position = 9)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Next OfKinOrAssociatedPartiesJobTitle (OBR.10)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 10
+     *
+     * @return bool
+     *
+     */
     public function setNextOfKinOrAssociatedPartiesJobTitle($value, int $position = 10)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Next OfKinOrAssociatedPartiesJobCodeOrClass (OBR.11)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 11
+     *
+     * @return bool
+     *
+     */
     public function setNextOfKinOrAssociatedPartiesJobCodeOrClass($value, int $position = 11)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Next OfKinOrAssociatedPartiesEmployeeNumber (OBR.12)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 12
+     *
+     * @return bool
+     *
+     */
     public function setNextOfKinOrAssociatedPartiesEmployeeNumber($value, int $position = 12)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Organization Name (OBR.13)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 13
+     *
+     * @return bool
+     *
+     */
     public function setOrganizationName($value, int $position = 13)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Marital Status (OBR.14)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 14
+     *
+     * @return bool
+     *
+     */
     public function setMaritalStatus($value, int $position = 14)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Administrative Sex (OBR.15)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 15
+     *
+     * @return bool
+     *
+     */
     public function setAdministrativeSex($value, int $position = 15)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Date TimeOfBirth (OBR.16)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 16
+     *
+     * @return bool
+     *
+     */
     public function setDateTimeOfBirth($value, int $position = 16)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Living Dependency (OBR.17)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 17
+     *
+     * @return bool
+     *
+     */
     public function setLivingDependency($value, int $position = 17)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Ambulatory Status (OBR.18)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 18
+     *
+     * @return bool
+     *
+     */
     public function setAmbulatoryStatus($value, int $position = 18)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Citizenship (OBR.19)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 19
+     *
+     * @return bool
+     *
+     */
     public function setCitizenship($value, int $position = 19)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Primary Language (OBR.20)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 20
+     *
+     * @return bool
+     *
+     */
     public function setPrimaryLanguage($value, int $position = 20)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Living Arrangement (OBR.21)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 21
+     *
+     * @return bool
+     *
+     */
     public function setLivingArrangement($value, int $position = 21)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Publicity Code (OBR.22)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 22
+     *
+     * @return bool
+     *
+     */
     public function setPublicityCode($value, int $position = 22)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Protection Indicator (OBR.23)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 23
+     *
+     * @return bool
+     *
+     */
     public function setProtectionIndicator($value, int $position = 23)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Student Indicator (OBR.24)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 24
+     *
+     * @return bool
+     *
+     */
     public function setStudentIndicator($value, int $position = 24)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Religion (OBR.25)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 25
+     *
+     * @return bool
+     *
+     */
     public function setReligion($value, int $position = 25)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Mothers MaidenName (OBR.26)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 26
+     *
+     * @return bool
+     *
+     */
     public function setMothersMaidenName($value, int $position = 26)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Nationality (OBR.27)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 27
+     *
+     * @return bool
+     *
+     */
     public function setNationality($value, int $position = 27)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Ethnic Group (OBR.28)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 28
+     *
+     * @return bool
+     *
+     */
     public function setEthnicGroup($value, int $position = 28)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Contact Reason (OBR.29)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 29
+     *
+     * @return bool
+     *
+     */
     public function setContactReason($value, int $position = 29)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Contact PersonsName (OBR.30)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 30
+     *
+     * @return bool
+     *
+     */
     public function setContactPersonsName($value, int $position = 30)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Contact PersonsTelephoneNumber (OBR.31)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 31
+     *
+     * @return bool
+     *
+     */
     public function setContactPersonsTelephoneNumber($value, int $position = 31)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Contact PersonsAddress (OBR.32)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 32
+     *
+     * @return bool
+     *
+     */
     public function setContactPersonsAddress($value, int $position = 32)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Next OfKinOrAssociatedPartysIdentifiers (OBR.33)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 33
+     *
+     * @return bool
+     *
+     */
     public function setNextOfKinOrAssociatedPartysIdentifiers($value, int $position = 33)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Job Status (OBR.34)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 34
+     *
+     * @return bool
+     *
+     */
     public function setJobStatus($value, int $position = 34)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Race (OBR.35)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 35
+     *
+     * @return bool
+     *
+     */
     public function setRace($value, int $position = 35)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Handicap (OBR.36)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 36
+     *
+     * @return bool
+     *
+     */
     public function setHandicap($value, int $position = 36)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Contact PersonSocialSecurityNumber (OBR.37)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 37
+     *
+     * @return bool
+     *
+     */
     public function setContactPersonSocialSecurityNumber($value, int $position = 37)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Next OfKinBirthPlace (OBR.38)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 38
+     *
+     * @return bool
+     *
+     */
     public function setNextOfKinBirthPlace($value, int $position = 38)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Vip Indicator (OBR.39)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 39
+     *
+     * @return bool
+     *
+     */
     public function setVipIndicator($value, int $position = 39)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Get ID (OBR.1)
+     *
+     * @param int $position Defaults to 1
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getID(int $position = 1)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get NKName (OBR.2)
+     *
+     * @param int $position Defaults to 2
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getNKName(int $position = 2)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Relationship (OBR.3)
+     *
+     * @param int $position Defaults to 3
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getRelationship(int $position = 3)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Address (OBR.4)
+     *
+     * @param int $position Defaults to 4
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getAddress(int $position = 4)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Phone Number (OBR.5)
+     *
+     * @param int $position Defaults to 5
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getPhoneNumber(int $position = 5)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Business PhoneNumber (OBR.6)
+     *
+     * @param int $position Defaults to 6
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getBusinessPhoneNumber(int $position = 6)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Contact Role (OBR.7)
+     *
+     * @param int $position Defaults to 7
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getContactRole(int $position = 7)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Start Date (OBR.8)
+     *
+     * @param int $position Defaults to 8
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getStartDate(int $position = 8)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get End Date (OBR.9)
+     *
+     * @param int $position Defaults to 9
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getEndDate(int $position = 9)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Next OfKinOrAssociatedPartiesJobTitle (OBR.10)
+     *
+     * @param int $position Defaults to 10
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getNextOfKinOrAssociatedPartiesJobTitle(int $position = 10)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Next OfKinOrAssociatedPartiesJobCodeOrClass (OBR.11)
+     *
+     * @param int $position Defaults to 11
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getNextOfKinOrAssociatedPartiesJobCodeOrClass(int $position = 11)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Next OfKinOrAssociatedPartiesEmployeeNumber (OBR.12)
+     *
+     * @param int $position Defaults to 12
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getNextOfKinOrAssociatedPartiesEmployeeNumber(int $position = 12)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Organization Name (OBR.13)
+     *
+     * @param int $position Defaults to 13
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getOrganizationName(int $position = 13)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Marital Status (OBR.14)
+     *
+     * @param int $position Defaults to 14
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getMaritalStatus(int $position = 14)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Administrative Sex (OBR.15)
+     *
+     * @param int $position Defaults to 15
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getAdministrativeSex(int $position = 15)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Date TimeOfBirth (OBR.16)
+     *
+     * @param int $position Defaults to 16
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getDateTimeOfBirth(int $position = 16)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Living Dependency (OBR.17)
+     *
+     * @param int $position Defaults to 17
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getLivingDependency(int $position = 17)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Ambulatory Status (OBR.18)
+     *
+     * @param int $position Defaults to 18
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getAmbulatoryStatus(int $position = 18)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Citizenship (OBR.19)
+     *
+     * @param int $position Defaults to 19
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getCitizenship(int $position = 19)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Primary Language (OBR.20)
+     *
+     * @param int $position Defaults to 20
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getPrimaryLanguage(int $position = 20)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Living Arrangement (OBR.21)
+     *
+     * @param int $position Defaults to 21
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getLivingArrangement(int $position = 21)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Publicity Code (OBR.22)
+     *
+     * @param int $position Defaults to 22
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getPublicityCode(int $position = 22)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Protection Indicator (OBR.23)
+     *
+     * @param int $position Defaults to 23
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getProtectionIndicator(int $position = 23)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Student Indicator (OBR.24)
+     *
+     * @param int $position Defaults to 24
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getStudentIndicator(int $position = 24)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Religion (OBR.25)
+     *
+     * @param int $position Defaults to 25
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getReligion(int $position = 25)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Mothers MaidenName (OBR.26)
+     *
+     * @param int $position Defaults to 26
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getMothersMaidenName(int $position = 26)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Nationality (OBR.27)
+     *
+     * @param int $position Defaults to 27
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getNationality(int $position = 27)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Ethnic Group (OBR.28)
+     *
+     * @param int $position Defaults to 28
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getEthnicGroup(int $position = 28)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Contact Reason (OBR.29)
+     *
+     * @param int $position Defaults to 29
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getContactReason(int $position = 29)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Contact PersonsName (OBR.30)
+     *
+     * @param int $position Defaults to 30
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getContactPersonsName(int $position = 30)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Contact PersonsTelephoneNumber (OBR.31)
+     *
+     * @param int $position Defaults to 31
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getContactPersonsTelephoneNumber(int $position = 31)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Contact PersonsAddress (OBR.32)
+     *
+     * @param int $position Defaults to 32
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getContactPersonsAddress(int $position = 32)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Next OfKinOrAssociatedPartysIdentifiers (OBR.33)
+     *
+     * @param int $position Defaults to 33
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getNextOfKinOrAssociatedPartysIdentifiers(int $position = 33)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Job Status (OBR.34)
+     *
+     * @param int $position Defaults to 34
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getJobStatus(int $position = 34)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Race (OBR.35)
+     *
+     * @param int $position Defaults to 35
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getRace(int $position = 35)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Handicap (OBR.36)
+     *
+     * @param int $position Defaults to 36
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getHandicap(int $position = 36)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Contact PersonSocialSecurityNumber (OBR.37)
+     *
+     * @param int $position Defaults to 37
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getContactPersonSocialSecurityNumber(int $position = 37)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Next OfKinBirthPlace (OBR.38)
+     *
+     * @param int $position Defaults to 38
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getNextOfKinBirthPlace(int $position = 38)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Vip Indicator (OBR.39)
+     *
+     * @param int $position Defaults to 39
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getVipIndicator(int $position = 39)
     {
         return $this->getField($position);

--- a/src/HL7/Segments/NTE.php
+++ b/src/HL7/Segments/NTE.php
@@ -44,36 +44,95 @@ class NTE extends Segment
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Source OfComment (OBR.2)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 2
+     *
+     * @return bool
+     *
+     */
     public function setSourceOfComment($value, int $position = 2)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Comment (OBR.3)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 3
+     *
+     * @return bool
+     *
+     */
     public function setComment($value, int $position = 3)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Comment Type (OBR.4)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 4
+     *
+     * @return bool
+     *
+     */
     public function setCommentType($value, int $position = 4)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Get ID (OBR.1)
+     *
+     * @param int $position Defaults to 1
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getID(int $position = 1)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Source OfComment (OBR.2)
+     *
+     * @param int $position Defaults to 2
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getSourceOfComment(int $position = 2)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Comment (OBR.3)
+     *
+     * @param int $position Defaults to 3
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getComment(int $position = 3)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Comment Type (OBR.4)
+     *
+     * @param int $position Defaults to 4
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getCommentType(int $position = 4)
     {
         return $this->getField($position);

--- a/src/HL7/Segments/OBR.php
+++ b/src/HL7/Segments/OBR.php
@@ -44,81 +44,225 @@ class OBR extends Segment
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Placer OrderNumber (OBR.2)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 2
+     *
+     * @return bool
+     *
+     */
     public function setPlacerOrderNumber($value, int $position = 2)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Filler OrderNumber (OBR.3)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 3
+     *
+     * @return bool
+     *
+     */
     public function setFillerOrderNumber($value, int $position = 3)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Universal ServiceID (OBR.4)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 4
+     *
+     * @return bool
+     *
+     */
     public function setUniversalServiceID($value, int $position = 4)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Priority (OBR.5)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 5
+     *
+     * @return bool
+     *
+     */
     public function setPriority($value, int $position = 5)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Requested Datetime (OBR.6)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 6
+     *
+     * @return bool
+     *
+     */
     public function setRequestedDatetime($value, int $position = 6)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Observation DateTime (OBR.7)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 7
+     *
+     * @return bool
+     *
+     */
     public function setObservationDateTime($value, int $position = 7)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Observation EndDateTime (OBR.8)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 8
+     *
+     * @return bool
+     *
+     */
     public function setObservationEndDateTime($value, int $position = 8)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Collection Volume (OBR.9)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 9
+     *
+     * @return bool
+     *
+     */
     public function setCollectionVolume($value, int $position = 9)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Collector Identifier (OBR.10)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 10
+     *
+     * @return bool
+     *
+     */
     public function setCollectorIdentifier($value, int $position = 10)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Specimen ActionCode (OBR.11)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 11
+     *
+     * @return bool
+     *
+     */
     public function setSpecimenActionCode($value, int $position = 11)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Danger Code (OBR.12)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 12
+     *
+     * @return bool
+     *
+     */
     public function setDangerCode($value, int $position = 12)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Relevant ClinicalInfo (OBR.13)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 13
+     *
+     * @return bool
+     *
+     */
     public function setRelevantClinicalInfo($value, int $position = 13)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Specimen ReceivedDateTime (OBR.14)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 14
+     *
+     * @return bool
+     *
+     */
     public function setSpecimenReceivedDateTime($value, int $position = 14)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Specimen Source (OBR.15)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 15
+     *
+     * @return bool
+     *
+     */
     public function setSpecimenSource($value, int $position = 15)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Ordering Provider (OBR.16)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 16
+     *
+     * @return bool
+     *
+     */
     public function setOrderingProvider($value, int $position = 16)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Order CallbackPhoneNumber (OBR.17)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 17
+     *
+     * @return bool
+     *
+     */
     public function setOrderCallbackPhoneNumber($value, int $position = 17)
     {
         return $this->setField($position, $value);
@@ -155,196 +299,530 @@ class OBR extends Segment
      *
      * @return bool
      */
+    /**
+     * Set Results RptStatusChngDateTime (OBR.22)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 22
+     *
+     * @return bool
+     *
+     */
     public function setResultsRptStatusChngDateTime($value, int $position = 22)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Chargeto Practice (OBR.23)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 23
+     *
+     * @return bool
+     *
+     */
     public function setChargetoPractice($value, int $position = 23)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Diagnostic ServSectID (OBR.24)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 24
+     *
+     * @return bool
+     *
+     */
     public function setDiagnosticServSectID($value, int $position = 24)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Result Status (OBR.25)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 25
+     *
+     * @return bool
+     *
+     */
     public function setResultStatus($value, int $position = 25)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Parent Result (OBR.26)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 26
+     *
+     * @return bool
+     *
+     */
     public function setParentResult($value, int $position = 26)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Quantity Timing (OBR.27)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 27
+     *
+     * @return bool
+     *
+     */
     public function setQuantityTiming($value, int $position = 27)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Result CopiesTo (OBR.28)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 28
+     *
+     * @return bool
+     *
+     */
     public function setResultCopiesTo($value, int $position = 28)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Parent (OBR.29)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 29
+     *
+     * @return bool
+     *
+     */
     public function setParent($value, int $position = 29)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Transportation Mode (OBR.30)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 30
+     *
+     * @return bool
+     *
+     */
     public function setTransportationMode($value, int $position = 30)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Reasonfor Study (OBR.31)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 31
+     *
+     * @return bool
+     *
+     */
     public function setReasonforStudy($value, int $position = 31)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Principal ResultInterpreter (OBR.32)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 32
+     *
+     * @return bool
+     *
+     */
     public function setPrincipalResultInterpreter($value, int $position = 32)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Assistant ResultInterpreter (OBR.33)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 33
+     *
+     * @return bool
+     *
+     */
     public function setAssistantResultInterpreter($value, int $position = 33)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Technician (OBR.34)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 34
+     *
+     * @return bool
+     *
+     */
     public function setTechnician($value, int $position = 34)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Transcriptionist (OBR.35)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 35
+     *
+     * @return bool
+     *
+     */
     public function setTranscriptionist($value, int $position = 35)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Scheduled DateTime (OBR.36)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 36
+     *
+     * @return bool
+     *
+     */
     public function setScheduledDateTime($value, int $position = 36)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Numberof SampleContainers (OBR.37)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 37
+     *
+     * @return bool
+     *
+     */
     public function setNumberofSampleContainers($value, int $position = 37)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Transport LogisticsofCollectedSample (OBR.38)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 38
+     *
+     * @return bool
+     *
+     */
     public function setTransportLogisticsofCollectedSample($value, int $position = 38)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Collectors Comment (OBR.39)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 39
+     *
+     * @return bool
+     *
+     */
     public function setCollectorsComment($value, int $position = 39)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Transport ArrangementResponsibility (OBR.40)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 40
+     *
+     * @return bool
+     *
+     */
     public function setTransportArrangementResponsibility($value, int $position = 40)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Transport Arranged (OBR.41)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 41
+     *
+     * @return bool
+     *
+     */
     public function setTransportArranged($value, int $position = 41)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Escort Required (OBR.42)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 42
+     *
+     * @return bool
+     *
+     */
     public function setEscortRequired($value, int $position = 42)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Planned PatientTransportComment (OBR.43)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 43
+     *
+     * @return bool
+     *
+     */
     public function setPlannedPatientTransportComment($value, int $position = 43)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Get ID (OBR.1)
+     *
+     * @param int $position Defaults to 1
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getID(int $position = 1)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Placer OrderNumber (OBR.2)
+     *
+     * @param int $position Defaults to 2
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getPlacerOrderNumber(int $position = 2)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Filler OrderNumber (OBR.3)
+     *
+     * @param int $position Defaults to 3
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getFillerOrderNumber(int $position = 3)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Universal ServiceID (OBR.4)
+     *
+     * @param int $position Defaults to 4
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getUniversalServiceID(int $position = 4)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Priority (OBR.5)
+     *
+     * @param int $position Defaults to 5
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getPriority(int $position = 5)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Requested Datetime (OBR.6)
+     *
+     * @param int $position Defaults to 6
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getRequestedDatetime(int $position = 6)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Observation DateTime (OBR.7)
+     *
+     * @param int $position Defaults to 7
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getObservationDateTime(int $position = 7)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Observation EndDateTime (OBR.8)
+     *
+     * @param int $position Defaults to 8
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getObservationEndDateTime(int $position = 8)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Collection Volume (OBR.9)
+     *
+     * @param int $position Defaults to 9
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getCollectionVolume(int $position = 9)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Collector Identifier (OBR.10)
+     *
+     * @param int $position Defaults to 10
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getCollectorIdentifier(int $position = 10)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Specimen ActionCode (OBR.11)
+     *
+     * @param int $position Defaults to 11
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getSpecimenActionCode(int $position = 11)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Danger Code (OBR.12)
+     *
+     * @param int $position Defaults to 12
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getDangerCode(int $position = 12)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Relevant ClinicalInfo (OBR.13)
+     *
+     * @param int $position Defaults to 13
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getRelevantClinicalInfo(int $position = 13)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Specimen ReceivedDateTime (OBR.14)
+     *
+     * @param int $position Defaults to 14
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getSpecimenReceivedDateTime(int $position = 14)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Specimen Source (OBR.15)
+     *
+     * @param int $position Defaults to 15
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getSpecimenSource(int $position = 15)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Ordering Provider (OBR.16)
+     *
+     * @param int $position Defaults to 16
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getOrderingProvider(int $position = 16)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Order CallbackPhoneNumber (OBR.17)
+     *
+     * @param int $position Defaults to 17
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getOrderCallbackPhoneNumber(int $position = 17)
     {
         return $this->getField($position);
@@ -370,111 +848,287 @@ class OBR extends Segment
         return $this->getField($position);
     }
 
+    /**
+     * Get Results RptStatusChngDateTime (OBR.22)
+     *
+     * @param int $position Defaults to 22
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getResultsRptStatusChngDateTime(int $position = 22)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Chargeto Practice (OBR.23)
+     *
+     * @param int $position Defaults to 23
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getChargetoPractice(int $position = 23)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Diagnostic ServSectID (OBR.24)
+     *
+     * @param int $position Defaults to 24
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getDiagnosticServSectID(int $position = 24)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Result Status (OBR.25)
+     *
+     * @param int $position Defaults to 25
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getResultStatus(int $position = 25)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Parent Result (OBR.26)
+     *
+     * @param int $position Defaults to 26
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getParentResult(int $position = 26)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Quantity Timing (OBR.27)
+     *
+     * @param int $position Defaults to 27
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getQuantityTiming(int $position = 27)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Result CopiesTo (OBR.28)
+     *
+     * @param int $position Defaults to 28
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getResultCopiesTo(int $position = 28)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Parent (OBR.29)
+     *
+     * @param int $position Defaults to 29
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getParent(int $position = 29)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Transportation Mode (OBR.30)
+     *
+     * @param int $position Defaults to 30
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getTransportationMode(int $position = 30)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Reasonfor Study (OBR.31)
+     *
+     * @param int $position Defaults to 31
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getReasonforStudy(int $position = 31)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Principal ResultInterpreter (OBR.32)
+     *
+     * @param int $position Defaults to 32
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getPrincipalResultInterpreter(int $position = 32)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Assistant ResultInterpreter (OBR.33)
+     *
+     * @param int $position Defaults to 33
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getAssistantResultInterpreter(int $position = 33)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Technician (OBR.34)
+     *
+     * @param int $position Defaults to 34
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getTechnician(int $position = 34)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Transcriptionist (OBR.35)
+     *
+     * @param int $position Defaults to 35
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getTranscriptionist(int $position = 35)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Scheduled DateTime (OBR.36)
+     *
+     * @param int $position Defaults to 36
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getScheduledDateTime(int $position = 36)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Numberof SampleContainers (OBR.37)
+     *
+     * @param int $position Defaults to 37
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getNumberofSampleContainers(int $position = 37)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Transport LogisticsofCollectedSample (OBR.38)
+     *
+     * @param int $position Defaults to 38
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getTransportLogisticsofCollectedSample(int $position = 38)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Collectors Comment (OBR.39)
+     *
+     * @param int $position Defaults to 39
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getCollectorsComment(int $position = 39)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Transport ArrangementResponsibility (OBR.40)
+     *
+     * @param int $position Defaults to 40
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getTransportArrangementResponsibility(int $position = 40)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Transport Arranged (OBR.41)
+     *
+     * @param int $position Defaults to 41
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getTransportArranged(int $position = 41)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Escort Required (OBR.42)
+     *
+     * @param int $position Defaults to 42
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getEscortRequired(int $position = 42)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Planned PatientTransportComment (OBR.43)
+     *
+     * @param int $position Defaults to 43
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getPlannedPatientTransportComment(int $position = 43)
     {
         return $this->getField($position);

--- a/src/HL7/Segments/OBX.php
+++ b/src/HL7/Segments/OBX.php
@@ -43,186 +43,500 @@ class OBX extends Segment
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Value Type (OBR.2)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 2
+     *
+     * @return bool
+     *
+     */
     public function setValueType($value, int $position = 2)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Observation Identifier (OBR.3)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 3
+     *
+     * @return bool
+     *
+     */
     public function setObservationIdentifier($value, int $position = 3)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Observation SubId (OBR.4)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 4
+     *
+     * @return bool
+     *
+     */
     public function setObservationSubId($value, int $position = 4)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Observation Value (OBR.5)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 5
+     *
+     * @return bool
+     *
+     */
     public function setObservationValue($value, int $position = 5)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Units (OBR.6)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 6
+     *
+     * @return bool
+     *
+     */
     public function setUnits($value, int $position = 6)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Reference Range (OBR.7)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 7
+     *
+     * @return bool
+     *
+     */
     public function setReferenceRange($value, int $position = 7)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Abnormal Flags (OBR.8)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 8
+     *
+     * @return bool
+     *
+     */
     public function setAbnormalFlags($value, int $position = 8)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Probability (OBR.9)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 9
+     *
+     * @return bool
+     *
+     */
     public function setProbability($value, int $position = 9)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Nature OfAbnormalTest (OBR.10)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 10
+     *
+     * @return bool
+     *
+     */
     public function setNatureOfAbnormalTest($value, int $position = 10)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Observe ResultStatus (OBR.11)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 11
+     *
+     * @return bool
+     *
+     */
     public function setObserveResultStatus($value, int $position = 11)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Data LastObsNormalValues (OBR.12)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 12
+     *
+     * @return bool
+     *
+     */
     public function setDataLastObsNormalValues($value, int $position = 12)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set User DefinedAccessChecks (OBR.13)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 13
+     *
+     * @return bool
+     *
+     */
     public function setUserDefinedAccessChecks($value, int $position = 13)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Date TimeOfTheObservation (OBR.14)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 14
+     *
+     * @return bool
+     *
+     */
     public function setDateTimeOfTheObservation($value, int $position = 14)
     {
            return $this->setField($position, $value);
     }
 
+    /**
+     * Set Producers Id (OBR.15)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 15
+     *
+     * @return bool
+     *
+     */
     public function setProducersId($value, int $position = 15)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Responsible Observer (OBR.16)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 16
+     *
+     * @return bool
+     *
+     */
     public function setResponsibleObserver($value, int $position = 16)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Observation Method (OBR.17)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 17
+     *
+     * @return bool
+     *
+     */
     public function setObservationMethod($value, int $position = 17)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Equipment InstanceIdentifier (OBR.18)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 18
+     *
+     * @return bool
+     *
+     */
     public function setEquipmentInstanceIdentifier($value, int $position = 18)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Date TimeOfAnalysis (OBR.19)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 19
+     *
+     * @return bool
+     *
+     */
     public function setDateTimeOfAnalysis($value, int $position = 19)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Get ID (OBR.1)
+     *
+     * @param int $position Defaults to 1
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getID(int $position = 1)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Value Type (OBR.2)
+     *
+     * @param int $position Defaults to 2
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getValueType(int $position = 2)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Observation Identifier (OBR.3)
+     *
+     * @param int $position Defaults to 3
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getObservationIdentifier(int $position = 3)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Observation SubId (OBR.4)
+     *
+     * @param int $position Defaults to 4
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getObservationSubId(int $position = 4)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Observation Value (OBR.5)
+     *
+     * @param int $position Defaults to 5
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getObservationValue(int $position = 5)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Units (OBR.6)
+     *
+     * @param int $position Defaults to 6
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getUnits(int $position = 6)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Reference Range (OBR.7)
+     *
+     * @param int $position Defaults to 7
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getReferenceRange(int $position = 7)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Abnormal Flags (OBR.8)
+     *
+     * @param int $position Defaults to 8
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getAbnormalFlags(int $position = 8)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Probability (OBR.9)
+     *
+     * @param int $position Defaults to 9
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getProbability(int $position = 9)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Nature OfAbnormalTest (OBR.10)
+     *
+     * @param int $position Defaults to 10
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getNatureOfAbnormalTest(int $position = 10)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Observe ResultStatus (OBR.11)
+     *
+     * @param int $position Defaults to 11
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getObserveResultStatus(int $position = 11)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Data LastObsNormalValues (OBR.12)
+     *
+     * @param int $position Defaults to 12
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getDataLastObsNormalValues(int $position = 12)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get User DefinedAccessChecks (OBR.13)
+     *
+     * @param int $position Defaults to 13
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getUserDefinedAccessChecks(int $position = 13)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Date TimeOfTheObservation (OBR.14)
+     *
+     * @param int $position Defaults to 14
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getDateTimeOfTheObservation(int $position = 14)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Producers Id (OBR.15)
+     *
+     * @param int $position Defaults to 15
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getProducersId(int $position = 15)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Responsible Observer (OBR.16)
+     *
+     * @param int $position Defaults to 16
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getResponsibleObserver(int $position = 16)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Observation Method (OBR.17)
+     *
+     * @param int $position Defaults to 17
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getObservationMethod(int $position = 17)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Equipment InstanceIdentifier (OBR.18)
+     *
+     * @param int $position Defaults to 18
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getEquipmentInstanceIdentifier(int $position = 18)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Date TimeOfAnalysis (OBR.19)
+     *
+     * @param int $position Defaults to 19
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getDateTimeOfAnalysis(int $position = 19)
     {
         return $this->getField($position);

--- a/src/HL7/Segments/ORC.php
+++ b/src/HL7/Segments/ORC.php
@@ -17,311 +17,838 @@ class ORC extends Segment
         parent::__construct('ORC', $fields);
     }
 
+    /**
+     * Set Order Control (OBR.1)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 1
+     *
+     * @return bool
+     *
+     */
     public function setOrderControl($value, int $position = 1)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Placer OrderNumber (OBR.2)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 2
+     *
+     * @return bool
+     *
+     */
     public function setPlacerOrderNumber($value, int $position = 2)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Filler OrderNumber (OBR.3)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 3
+     *
+     * @return bool
+     *
+     */
     public function setFillerOrderNumber($value, int $position = 3)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Placer GroupNumber (OBR.4)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 4
+     *
+     * @return bool
+     *
+     */
     public function setPlacerGroupNumber($value, int $position = 4)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Order Status (OBR.5)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 5
+     *
+     * @return bool
+     *
+     */
     public function setOrderStatus($value, int $position = 5)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Response Flag (OBR.6)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 6
+     *
+     * @return bool
+     *
+     */
     public function setResponseFlag($value, int $position = 6)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Quantity Timing (OBR.7)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 7
+     *
+     * @return bool
+     *
+     */
     public function setQuantityTiming($value, int $position = 7)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Parent Order (OBR.8)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 8
+     *
+     * @return bool
+     *
+     */
     public function setParentOrder($value, int $position = 8)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Date TimeofTransaction (OBR.9)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 9
+     *
+     * @return bool
+     *
+     */
     public function setDateTimeofTransaction($value, int $position = 9)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Entered By (OBR.10)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 10
+     *
+     * @return bool
+     *
+     */
     public function setEnteredBy($value, int $position = 10)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Verified By (OBR.11)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 11
+     *
+     * @return bool
+     *
+     */
     public function setVerifiedBy($value, int $position = 11)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Ordering Provider (OBR.12)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 12
+     *
+     * @return bool
+     *
+     */
     public function setOrderingProvider($value, int $position = 12)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Enterers Location (OBR.13)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 13
+     *
+     * @return bool
+     *
+     */
     public function setEnterersLocation($value, int $position = 13)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Call BackPhoneNumber (OBR.14)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 14
+     *
+     * @return bool
+     *
+     */
     public function setCallBackPhoneNumber($value, int $position = 14)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Order EffectiveDateTime (OBR.15)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 15
+     *
+     * @return bool
+     *
+     */
     public function setOrderEffectiveDateTime($value, int $position = 15)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Order ControlCodeReason (OBR.16)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 16
+     *
+     * @return bool
+     *
+     */
     public function setOrderControlCodeReason($value, int $position = 16)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Entering Organization (OBR.17)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 17
+     *
+     * @return bool
+     *
+     */
     public function setEnteringOrganization($value, int $position = 17)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Entering Device (OBR.18)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 18
+     *
+     * @return bool
+     *
+     */
     public function setEnteringDevice($value, int $position = 18)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Action By (OBR.19)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 19
+     *
+     * @return bool
+     *
+     */
     public function setActionBy($value, int $position = 19)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Advanced BeneficiaryNoticeCode (OBR.20)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 20
+     *
+     * @return bool
+     *
+     */
     public function setAdvancedBeneficiaryNoticeCode($value, int $position = 20)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Ordering FacilityName (OBR.21)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 21
+     *
+     * @return bool
+     *
+     */
     public function setOrderingFacilityName($value, int $position = 21)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Ordering FacilityAddress (OBR.22)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 22
+     *
+     * @return bool
+     *
+     */
     public function setOrderingFacilityAddress($value, int $position = 22)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Ordering FacilityPhoneNumber (OBR.23)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 23
+     *
+     * @return bool
+     *
+     */
     public function setOrderingFacilityPhoneNumber($value, int $position = 23)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Ordering ProviderAddress (OBR.24)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 24
+     *
+     * @return bool
+     *
+     */
     public function setOrderingProviderAddress($value, int $position = 24)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Order StatusModifier (OBR.25)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 25
+     *
+     * @return bool
+     *
+     */
     public function setOrderStatusModifier($value, int $position = 25)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Advanced BeneficiaryNoticeOverrideReason (OBR.26)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 26
+     *
+     * @return bool
+     *
+     */
     public function setAdvancedBeneficiaryNoticeOverrideReason($value, int $position = 26)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Fillers ExpectedAvailabilityDateTime (OBR.27)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 27
+     *
+     * @return bool
+     *
+     */
     public function setFillersExpectedAvailabilityDateTime($value, int $position = 27)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Confidentiality Code (OBR.28)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 28
+     *
+     * @return bool
+     *
+     */
     public function setConfidentialityCode($value, int $position = 28)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Order Type (OBR.29)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 29
+     *
+     * @return bool
+     *
+     */
     public function setOrderType($value, int $position = 29)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Enterer AuthorizationMode (OBR.30)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 30
+     *
+     * @return bool
+     *
+     */
     public function setEntererAuthorizationMode($value, int $position = 30)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Parent UniversalServiceIdentifier (OBR.31)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 31
+     *
+     * @return bool
+     *
+     */
     public function setParentUniversalServiceIdentifier($value, int $position = 31)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Get Order Control (OBR.1)
+     *
+     * @param int $position Defaults to 1
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getOrderControl(int $position = 1)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Placer OrderNumber (OBR.2)
+     *
+     * @param int $position Defaults to 2
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getPlacerOrderNumber(int $position = 2)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Filler OrderNumber (OBR.3)
+     *
+     * @param int $position Defaults to 3
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getFillerOrderNumber(int $position = 3)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Placer GroupNumber (OBR.4)
+     *
+     * @param int $position Defaults to 4
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getPlacerGroupNumber(int $position = 4)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Order Status (OBR.5)
+     *
+     * @param int $position Defaults to 5
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getOrderStatus(int $position = 5)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Response Flag (OBR.6)
+     *
+     * @param int $position Defaults to 6
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getResponseFlag(int $position = 6)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Quantity Timing (OBR.7)
+     *
+     * @param int $position Defaults to 7
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getQuantityTiming(int $position = 7)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Parent Order (OBR.8)
+     *
+     * @param int $position Defaults to 8
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getParentOrder(int $position = 8)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Date TimeofTransaction (OBR.9)
+     *
+     * @param int $position Defaults to 9
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getDateTimeofTransaction(int $position = 9)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Entered By (OBR.10)
+     *
+     * @param int $position Defaults to 10
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getEnteredBy(int $position = 10)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Verified By (OBR.11)
+     *
+     * @param int $position Defaults to 11
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getVerifiedBy(int $position = 11)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Ordering Provider (OBR.12)
+     *
+     * @param int $position Defaults to 12
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getOrderingProvider(int $position = 12)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Enterers Location (OBR.13)
+     *
+     * @param int $position Defaults to 13
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getEnterersLocation(int $position = 13)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Call BackPhoneNumber (OBR.14)
+     *
+     * @param int $position Defaults to 14
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getCallBackPhoneNumber(int $position = 14)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Order EffectiveDateTime (OBR.15)
+     *
+     * @param int $position Defaults to 15
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getOrderEffectiveDateTime(int $position = 15)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Order ControlCodeReason (OBR.16)
+     *
+     * @param int $position Defaults to 16
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getOrderControlCodeReason(int $position = 16)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Entering Organization (OBR.17)
+     *
+     * @param int $position Defaults to 17
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getEnteringOrganization(int $position = 17)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Entering Device (OBR.18)
+     *
+     * @param int $position Defaults to 18
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getEnteringDevice(int $position = 18)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Action By (OBR.19)
+     *
+     * @param int $position Defaults to 19
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getActionBy(int $position = 19)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Advanced BeneficiaryNoticeCode (OBR.20)
+     *
+     * @param int $position Defaults to 20
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getAdvancedBeneficiaryNoticeCode(int $position = 20)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Ordering FacilityName (OBR.21)
+     *
+     * @param int $position Defaults to 21
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getOrderingFacilityName(int $position = 21)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Ordering FacilityAddress (OBR.22)
+     *
+     * @param int $position Defaults to 22
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getOrderingFacilityAddress(int $position = 22)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Ordering FacilityPhoneNumber (OBR.23)
+     *
+     * @param int $position Defaults to 23
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getOrderingFacilityPhoneNumber(int $position = 23)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Ordering ProviderAddress (OBR.24)
+     *
+     * @param int $position Defaults to 24
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getOrderingProviderAddress(int $position = 24)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Order StatusModifier (OBR.25)
+     *
+     * @param int $position Defaults to 25
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getOrderStatusModifier(int $position = 25)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Advanced BeneficiaryNoticeOverrideReason (OBR.26)
+     *
+     * @param int $position Defaults to 26
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getAdvancedBeneficiaryNoticeOverrideReason(int $position = 26)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Fillers ExpectedAvailabilityDateTime (OBR.27)
+     *
+     * @param int $position Defaults to 27
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getFillersExpectedAvailabilityDateTime(int $position = 27)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Confidentiality Code (OBR.28)
+     *
+     * @param int $position Defaults to 28
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getConfidentialityCode(int $position = 28)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Order Type (OBR.29)
+     *
+     * @param int $position Defaults to 29
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getOrderType(int $position = 29)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Enterer AuthorizationMode (OBR.30)
+     *
+     * @param int $position Defaults to 30
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getEntererAuthorizationMode(int $position = 30)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Parent UniversalServiceIdentifier (OBR.31)
+     *
+     * @param int $position Defaults to 31
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getParentUniversalServiceIdentifier(int $position = 31)
     {
         return $this->getField($position);

--- a/src/HL7/Segments/PID.php
+++ b/src/HL7/Segments/PID.php
@@ -44,6 +44,15 @@ class PID extends Segment
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Patient ID (OBR.2)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 2
+     *
+     * @return bool
+     *
+     */
     public function setPatientID($value, int $position = 2)
     {
         return $this->setField($position, $value);
@@ -53,26 +62,71 @@ class PID extends Segment
      * Patient ID (Internal ID)
      * @param string $value
      */
+    /**
+     * Set Patient IdentifierList (OBR.3)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 3
+     *
+     * @return bool
+     *
+     */
     public function setPatientIdentifierList($value, int $position = 3): bool
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Alternate PatientID (OBR.4)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 4
+     *
+     * @return bool
+     *
+     */
     public function setAlternatePatientID($value, int $position = 4)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Patient Name (OBR.5)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 5
+     *
+     * @return bool
+     *
+     */
     public function setPatientName($value, int $position = 5)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Mothers MaidenName (OBR.6)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 6
+     *
+     * @return bool
+     *
+     */
     public function setMothersMaidenName($value, int $position = 6)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Date TimeOfBirth (OBR.7)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 7
+     *
+     * @return bool
+     *
+     */
     public function setDateTimeOfBirth($value, int $position = 7)
     {
         // TODO: Validate if $value is of the form %Y%m%d%H%M%S
@@ -91,121 +145,335 @@ class PID extends Segment
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Patient Alias (OBR.9)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 9
+     *
+     * @return bool
+     *
+     */
     public function setPatientAlias($value, int $position = 9)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Race (OBR.10)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 10
+     *
+     * @return bool
+     *
+     */
     public function setRace($value, int $position = 10)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Patient Address (OBR.11)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 11
+     *
+     * @return bool
+     *
+     */
     public function setPatientAddress($value, int $position = 11)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Country Code (OBR.12)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 12
+     *
+     * @return bool
+     *
+     */
     public function setCountryCode($value, int $position = 12)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Phone NumberHome (OBR.13)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 13
+     *
+     * @return bool
+     *
+     */
     public function setPhoneNumberHome($value, int $position = 13)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Phone NumberBusiness (OBR.14)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 14
+     *
+     * @return bool
+     *
+     */
     public function setPhoneNumberBusiness($value, int $position = 14)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Primary Language (OBR.15)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 15
+     *
+     * @return bool
+     *
+     */
     public function setPrimaryLanguage($value, int $position = 15)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Marital Status (OBR.16)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 16
+     *
+     * @return bool
+     *
+     */
     public function setMaritalStatus($value, int $position = 16)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Religion (OBR.17)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 17
+     *
+     * @return bool
+     *
+     */
     public function setReligion($value, int $position = 17)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Patient AccountNumber (OBR.18)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 18
+     *
+     * @return bool
+     *
+     */
     public function setPatientAccountNumber($value, int $position = 18)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set SSNNumber (OBR.19)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 19
+     *
+     * @return bool
+     *
+     */
     public function setSSNNumber($value, int $position = 19)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Drivers LicenseNumber (OBR.20)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 20
+     *
+     * @return bool
+     *
+     */
     public function setDriversLicenseNumber($value, int $position = 20)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Mothers Identifier (OBR.21)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 21
+     *
+     * @return bool
+     *
+     */
     public function setMothersIdentifier($value, int $position = 21)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Ethnic Group (OBR.22)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 22
+     *
+     * @return bool
+     *
+     */
     public function setEthnicGroup($value, int $position = 22)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Birth Place (OBR.23)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 23
+     *
+     * @return bool
+     *
+     */
     public function setBirthPlace($value, int $position = 23)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Multiple BirthIndicator (OBR.24)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 24
+     *
+     * @return bool
+     *
+     */
     public function setMultipleBirthIndicator($value, int $position = 24)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Birth Order (OBR.25)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 25
+     *
+     * @return bool
+     *
+     */
     public function setBirthOrder($value, int $position = 25)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Citizenship (OBR.26)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 26
+     *
+     * @return bool
+     *
+     */
     public function setCitizenship($value, int $position = 26)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Veterans MilitaryStatus (OBR.27)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 27
+     *
+     * @return bool
+     *
+     */
     public function setVeteransMilitaryStatus($value, int $position = 27)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Nationality (OBR.28)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 28
+     *
+     * @return bool
+     *
+     */
     public function setNationality($value, int $position = 28)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Patient DeathDateAndTime (OBR.29)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 29
+     *
+     * @return bool
+     *
+     */
     public function setPatientDeathDateAndTime($value, int $position = 29)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Patient DeathIndicator (OBR.30)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 30
+     *
+     * @return bool
+     *
+     */
     public function setPatientDeathIndicator($value, int $position = 30)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Get ID (OBR.1)
+     *
+     * @param int $position Defaults to 1
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getID(int $position = 1)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Patient ID (OBR.2)
+     *
+     * @param int $position Defaults to 2
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getPatientID(int $position = 2)
     {
         return $this->getField($position);
@@ -215,141 +483,365 @@ class PID extends Segment
      * Patient ID (Internal ID)
      * @return array|null|string
      */
+    /**
+     * Get Patient IdentifierList (OBR.3)
+     *
+     * @param int $position Defaults to 3
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getPatientIdentifierList(int $position = 3)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Alternate PatientID (OBR.4)
+     *
+     * @param int $position Defaults to 4
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getAlternatePatientID(int $position = 4)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Patient Name (OBR.5)
+     *
+     * @param int $position Defaults to 5
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getPatientName(int $position = 5)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Mothers MaidenName (OBR.6)
+     *
+     * @param int $position Defaults to 6
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getMothersMaidenName(int $position = 6)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Date TimeOfBirth (OBR.7)
+     *
+     * @param int $position Defaults to 7
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getDateTimeOfBirth(int $position = 7)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Sex (OBR.8)
+     *
+     * @param int $position Defaults to 8
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getSex(int $position = 8)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Patient Alias (OBR.9)
+     *
+     * @param int $position Defaults to 9
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getPatientAlias(int $position = 9)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Race (OBR.10)
+     *
+     * @param int $position Defaults to 10
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getRace(int $position = 10)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Patient Address (OBR.11)
+     *
+     * @param int $position Defaults to 11
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getPatientAddress(int $position = 11)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Country Code (OBR.12)
+     *
+     * @param int $position Defaults to 12
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getCountryCode(int $position = 12)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Phone NumberHome (OBR.13)
+     *
+     * @param int $position Defaults to 13
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getPhoneNumberHome(int $position = 13)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Phone NumberBusiness (OBR.14)
+     *
+     * @param int $position Defaults to 14
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getPhoneNumberBusiness(int $position = 14)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Primary Language (OBR.15)
+     *
+     * @param int $position Defaults to 15
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getPrimaryLanguage(int $position = 15)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Marital Status (OBR.16)
+     *
+     * @param int $position Defaults to 16
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getMaritalStatus(int $position = 16)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Religion (OBR.17)
+     *
+     * @param int $position Defaults to 17
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getReligion(int $position = 17)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Patient AccountNumber (OBR.18)
+     *
+     * @param int $position Defaults to 18
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getPatientAccountNumber(int $position = 18)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get SSNNumber (OBR.19)
+     *
+     * @param int $position Defaults to 19
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getSSNNumber(int $position = 19)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Drivers LicenseNumber (OBR.20)
+     *
+     * @param int $position Defaults to 20
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getDriversLicenseNumber(int $position = 20)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Mothers Identifier (OBR.21)
+     *
+     * @param int $position Defaults to 21
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getMothersIdentifier(int $position = 21)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Ethnic Group (OBR.22)
+     *
+     * @param int $position Defaults to 22
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getEthnicGroup(int $position = 22)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Birth Place (OBR.23)
+     *
+     * @param int $position Defaults to 23
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getBirthPlace(int $position = 23)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Multiple BirthIndicator (OBR.24)
+     *
+     * @param int $position Defaults to 24
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getMultipleBirthIndicator(int $position = 24)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Birth Order (OBR.25)
+     *
+     * @param int $position Defaults to 25
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getBirthOrder(int $position = 25)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Citizenship (OBR.26)
+     *
+     * @param int $position Defaults to 26
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getCitizenship(int $position = 26)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Veterans MilitaryStatus (OBR.27)
+     *
+     * @param int $position Defaults to 27
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getVeteransMilitaryStatus(int $position = 27)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Nationality (OBR.28)
+     *
+     * @param int $position Defaults to 28
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getNationality(int $position = 28)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Patient DeathDateAndTime (OBR.29)
+     *
+     * @param int $position Defaults to 29
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getPatientDeathDateAndTime(int $position = 29)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Patient DeathIndicator (OBR.30)
+     *
+     * @param int $position Defaults to 30
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getPatientDeathIndicator(int $position = 30)
     {
         return $this->getField($position);

--- a/src/HL7/Segments/PV1.php
+++ b/src/HL7/Segments/PV1.php
@@ -44,11 +44,29 @@ class PV1 extends Segment
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Patient Class (OBR.2)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 2
+     *
+     * @return bool
+     *
+     */
     public function setPatientClass($value, int $position = 2)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Assigned PatientLocation (OBR.3)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 3
+     *
+     * @return bool
+     *
+     */
     public function setAssignedPatientLocation($value, int $position = 3)
     {
         return $this->setField($position, $value);
@@ -56,6 +74,15 @@ class PV1 extends Segment
 
     /**
      * @return bool
+     */
+    /**
+     * Set Admission Type (OBR.4)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 4
+     *
+     * @return bool
+     *
      */
     public function setAdmissionType($value, int $position = 4)
     {
@@ -65,6 +92,15 @@ class PV1 extends Segment
     /**
      * @return bool
      */
+    /**
+     * Set Pre AdmitNumber (OBR.5)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 5
+     *
+     * @return bool
+     *
+     */
     public function setPreAdmitNumber($value, int $position = 5)
     {
         return $this->setField($position, $value);
@@ -72,6 +108,15 @@ class PV1 extends Segment
 
     /**
      * @return bool
+     */
+    /**
+     * Set Prior PatientLocation (OBR.6)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 6
+     *
+     * @return bool
+     *
      */
     public function setPriorPatientLocation($value, int $position = 6)
     {
@@ -81,6 +126,15 @@ class PV1 extends Segment
     /**
      * @return bool
      */
+    /**
+     * Set Attending Doctor (OBR.7)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 7
+     *
+     * @return bool
+     *
+     */
     public function setAttendingDoctor($value, int $position = 7)
     {
         return $this->setField($position, $value);
@@ -88,6 +142,15 @@ class PV1 extends Segment
 
     /**
      * @return bool
+     */
+    /**
+     * Set Referring Doctor (OBR.8)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 8
+     *
+     * @return bool
+     *
      */
     public function setReferringDoctor($value, int $position = 8)
     {
@@ -97,6 +160,15 @@ class PV1 extends Segment
     /**
      * @return bool
      */
+    /**
+     * Set Consulting Doctor (OBR.9)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 9
+     *
+     * @return bool
+     *
+     */
     public function setConsultingDoctor($value, int $position = 9)
     {
         return $this->setField($position, $value);
@@ -104,6 +176,15 @@ class PV1 extends Segment
 
     /**
      * @return bool
+     */
+    /**
+     * Set Hospital Service (OBR.10)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 10
+     *
+     * @return bool
+     *
      */
     public function setHospitalService($value, int $position = 10)
     {
@@ -113,6 +194,15 @@ class PV1 extends Segment
     /**
      * @return bool
      */
+    /**
+     * Set Temporary Location (OBR.11)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 11
+     *
+     * @return bool
+     *
+     */
     public function setTemporaryLocation($value, int $position = 11)
     {
         return $this->setField($position, $value);
@@ -120,6 +210,15 @@ class PV1 extends Segment
 
     /**
      * @return bool
+     */
+    /**
+     * Set Pre AdmitTestIndicator (OBR.12)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 12
+     *
+     * @return bool
+     *
      */
     public function setPreAdmitTestIndicator($value, int $position = 12)
     {
@@ -129,6 +228,15 @@ class PV1 extends Segment
     /**
      * @return bool
      */
+    /**
+     * Set Re AdmissionIndicator (OBR.13)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 13
+     *
+     * @return bool
+     *
+     */
     public function setReAdmissionIndicator($value, int $position = 13)
     {
         return $this->setField($position, $value);
@@ -136,6 +244,15 @@ class PV1 extends Segment
 
     /**
      * @return bool
+     */
+    /**
+     * Set Admit Source (OBR.14)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 14
+     *
+     * @return bool
+     *
      */
     public function setAdmitSource($value, int $position = 14)
     {
@@ -145,6 +262,15 @@ class PV1 extends Segment
     /**
      * @return bool
      */
+    /**
+     * Set Ambulatory Status (OBR.15)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 15
+     *
+     * @return bool
+     *
+     */
     public function setAmbulatoryStatus($value, int $position = 15)
     {
         return $this->setField($position, $value);
@@ -152,6 +278,15 @@ class PV1 extends Segment
 
     /**
      * @return bool
+     */
+    /**
+     * Set Vip Indicator (OBR.16)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 16
+     *
+     * @return bool
+     *
      */
     public function setVipIndicator($value, int $position = 16)
     {
@@ -161,6 +296,15 @@ class PV1 extends Segment
     /**
      * @return bool
      */
+    /**
+     * Set Admitting Doctor (OBR.17)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 17
+     *
+     * @return bool
+     *
+     */
     public function setAdmittingDoctor($value, int $position = 17)
     {
         return $this->setField($position, $value);
@@ -168,6 +312,15 @@ class PV1 extends Segment
 
     /**
      * @return bool
+     */
+    /**
+     * Set Patient Type (OBR.18)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 18
+     *
+     * @return bool
+     *
      */
     public function setPatientType($value, int $position = 18)
     {
@@ -177,6 +330,15 @@ class PV1 extends Segment
     /**
      * @return bool
      */
+    /**
+     * Set Visit Number (OBR.19)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 19
+     *
+     * @return bool
+     *
+     */
     public function setVisitNumber($value, int $position = 19)
     {
         return $this->setField($position, $value);
@@ -184,6 +346,15 @@ class PV1 extends Segment
 
     /**
      * @return bool
+     */
+    /**
+     * Set Financial Class (OBR.20)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 20
+     *
+     * @return bool
+     *
      */
     public function setFinancialClass($value, int $position = 20)
     {
@@ -193,6 +364,15 @@ class PV1 extends Segment
     /**
      * @return bool
      */
+    /**
+     * Set Charge PriceIndicator (OBR.21)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 21
+     *
+     * @return bool
+     *
+     */
     public function setChargePriceIndicator($value, int $position = 21)
     {
         return $this->setField($position, $value);
@@ -200,6 +380,15 @@ class PV1 extends Segment
 
     /**
      * @return bool
+     */
+    /**
+     * Set Courtesy Code (OBR.22)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 22
+     *
+     * @return bool
+     *
      */
     public function setCourtesyCode($value, int $position = 22)
     {
@@ -209,6 +398,15 @@ class PV1 extends Segment
     /**
      * @return bool
      */
+    /**
+     * Set Credit Rating (OBR.23)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 23
+     *
+     * @return bool
+     *
+     */
     public function setCreditRating($value, int $position = 23)
     {
         return $this->setField($position, $value);
@@ -216,6 +414,15 @@ class PV1 extends Segment
 
     /**
      * @return bool
+     */
+    /**
+     * Set Contract Code (OBR.24)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 24
+     *
+     * @return bool
+     *
      */
     public function setContractCode($value, int $position = 24)
     {
@@ -225,6 +432,15 @@ class PV1 extends Segment
     /**
      * @return bool
      */
+    /**
+     * Set Contract EffectiveDate (OBR.25)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 25
+     *
+     * @return bool
+     *
+     */
     public function setContractEffectiveDate($value, int $position = 25)
     {
         return $this->setField($position, $value);
@@ -232,6 +448,15 @@ class PV1 extends Segment
 
     /**
      * @return bool
+     */
+    /**
+     * Set Contract Amount (OBR.26)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 26
+     *
+     * @return bool
+     *
      */
     public function setContractAmount($value, int $position = 26)
     {
@@ -241,6 +466,15 @@ class PV1 extends Segment
     /**
      * @return bool
      */
+    /**
+     * Set Contract Period (OBR.27)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 27
+     *
+     * @return bool
+     *
+     */
     public function setContractPeriod($value, int $position = 27)
     {
         return $this->setField($position, $value);
@@ -248,6 +482,15 @@ class PV1 extends Segment
 
     /**
      * @return bool
+     */
+    /**
+     * Set Interest Code (OBR.28)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 28
+     *
+     * @return bool
+     *
      */
     public function setInterestCode($value, int $position = 28)
     {
@@ -257,6 +500,15 @@ class PV1 extends Segment
     /**
      * @return bool
      */
+    /**
+     * Set Transfer ToBadDebtCode (OBR.29)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 29
+     *
+     * @return bool
+     *
+     */
     public function setTransferToBadDebtCode($value, int $position = 29)
     {
         return $this->setField($position, $value);
@@ -264,6 +516,15 @@ class PV1 extends Segment
 
     /**
      * @return bool
+     */
+    /**
+     * Set Transfer ToBadDebtDate (OBR.30)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 30
+     *
+     * @return bool
+     *
      */
     public function setTransferToBadDebtDate($value, int $position = 30)
     {
@@ -273,6 +534,15 @@ class PV1 extends Segment
     /**
      * @return bool
      */
+    /**
+     * Set Bad DebtAgencyCode (OBR.31)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 31
+     *
+     * @return bool
+     *
+     */
     public function setBadDebtAgencyCode($value, int $position = 31)
     {
         return $this->setField($position, $value);
@@ -280,6 +550,15 @@ class PV1 extends Segment
 
     /**
      * @return bool
+     */
+    /**
+     * Set Bad DebtTransferAmount (OBR.32)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 32
+     *
+     * @return bool
+     *
      */
     public function setBadDebtTransferAmount($value, int $position = 32)
     {
@@ -289,6 +568,15 @@ class PV1 extends Segment
     /**
      * @return bool
      */
+    /**
+     * Set Bad DebtRecoveryAmount (OBR.33)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 33
+     *
+     * @return bool
+     *
+     */
     public function setBadDebtRecoveryAmount($value, int $position = 33)
     {
         return $this->setField($position, $value);
@@ -296,6 +584,15 @@ class PV1 extends Segment
 
     /**
      * @return bool
+     */
+    /**
+     * Set Delete AccountIndicator (OBR.34)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 34
+     *
+     * @return bool
+     *
      */
     public function setDeleteAccountIndicator($value, int $position = 34)
     {
@@ -305,6 +602,15 @@ class PV1 extends Segment
     /**
      * @return bool
      */
+    /**
+     * Set Delete AccountDate (OBR.35)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 35
+     *
+     * @return bool
+     *
+     */
     public function setDeleteAccountDate($value, int $position = 35)
     {
         return $this->setField($position, $value);
@@ -312,6 +618,15 @@ class PV1 extends Segment
 
     /**
      * @return bool
+     */
+    /**
+     * Set Discharge Disposition (OBR.36)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 36
+     *
+     * @return bool
+     *
      */
     public function setDischargeDisposition($value, int $position = 36)
     {
@@ -321,6 +636,15 @@ class PV1 extends Segment
     /**
      * @return bool
      */
+    /**
+     * Set Discharged ToLocation (OBR.37)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 37
+     *
+     * @return bool
+     *
+     */
     public function setDischargedToLocation($value, int $position = 37)
     {
         return $this->setField($position, $value);
@@ -328,6 +652,15 @@ class PV1 extends Segment
 
     /**
      * @return bool
+     */
+    /**
+     * Set Diet Type (OBR.38)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 38
+     *
+     * @return bool
+     *
      */
     public function setDietType($value, int $position = 38)
     {
@@ -337,6 +670,15 @@ class PV1 extends Segment
     /**
      * @return bool
      */
+    /**
+     * Set Servicing Facility (OBR.39)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 39
+     *
+     * @return bool
+     *
+     */
     public function setServicingFacility($value, int $position = 39)
     {
         return $this->setField($position, $value);
@@ -344,6 +686,15 @@ class PV1 extends Segment
 
     /**
      * @return bool
+     */
+    /**
+     * Set Bed Status (OBR.40)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 40
+     *
+     * @return bool
+     *
      */
     public function setBedStatus($value, int $position = 40)
     {
@@ -353,6 +704,15 @@ class PV1 extends Segment
     /**
      * @return bool
      */
+    /**
+     * Set Account Status (OBR.41)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 41
+     *
+     * @return bool
+     *
+     */
     public function setAccountStatus($value, int $position = 41)
     {
         return $this->setField($position, $value);
@@ -360,6 +720,15 @@ class PV1 extends Segment
 
     /**
      * @return bool
+     */
+    /**
+     * Set Pending Location (OBR.42)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 42
+     *
+     * @return bool
+     *
      */
     public function setPendingLocation($value, int $position = 42)
     {
@@ -369,6 +738,15 @@ class PV1 extends Segment
     /**
      * @return bool
      */
+    /**
+     * Set Prior TemporaryLocation (OBR.43)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 43
+     *
+     * @return bool
+     *
+     */
     public function setPriorTemporaryLocation($value, int $position = 43)
     {
         return $this->setField($position, $value);
@@ -376,6 +754,15 @@ class PV1 extends Segment
 
     /**
      * @return bool
+     */
+    /**
+     * Set Admit DateTime (OBR.44)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 44
+     *
+     * @return bool
+     *
      */
     public function setAdmitDateTime($value, int $position = 44)
     {
@@ -385,6 +772,15 @@ class PV1 extends Segment
     /**
      * @return bool
      */
+    /**
+     * Set Discharge DateTime (OBR.45)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 45
+     *
+     * @return bool
+     *
+     */
     public function setDischargeDateTime($value, int $position = 45)
     {
         return $this->setField($position, $value);
@@ -392,6 +788,15 @@ class PV1 extends Segment
 
     /**
      * @return bool
+     */
+    /**
+     * Set Current PatientBalance (OBR.46)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 46
+     *
+     * @return bool
+     *
      */
     public function setCurrentPatientBalance($value, int $position = 46)
     {
@@ -401,6 +806,15 @@ class PV1 extends Segment
     /**
      * @return bool
      */
+    /**
+     * Set Total Charges (OBR.47)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 47
+     *
+     * @return bool
+     *
+     */
     public function setTotalCharges($value, int $position = 47)
     {
         return $this->setField($position, $value);
@@ -408,6 +822,15 @@ class PV1 extends Segment
 
     /**
      * @return bool
+     */
+    /**
+     * Set Total Adjustments (OBR.48)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 48
+     *
+     * @return bool
+     *
      */
     public function setTotalAdjustments($value, int $position = 48)
     {
@@ -417,6 +840,15 @@ class PV1 extends Segment
     /**
      * @return bool
      */
+    /**
+     * Set Total Payments (OBR.49)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 49
+     *
+     * @return bool
+     *
+     */
     public function setTotalPayments($value, int $position = 49)
     {
         return $this->setField($position, $value);
@@ -424,6 +856,15 @@ class PV1 extends Segment
 
     /**
      * @return bool
+     */
+    /**
+     * Set Alternate VisitID (OBR.50)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 50
+     *
+     * @return bool
+     *
      */
     public function setAlternateVisitID($value, int $position = 50)
     {
@@ -433,6 +874,15 @@ class PV1 extends Segment
     /**
      * @return bool
      */
+    /**
+     * Set Visit Indicator (OBR.51)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 51
+     *
+     * @return bool
+     *
+     */
     public function setVisitIndicator($value, int $position = 51)
     {
         return $this->setField($position, $value);
@@ -441,266 +891,691 @@ class PV1 extends Segment
     /**
      * @return bool
      */
+    /**
+     * Set Other HealthcareProvider (OBR.52)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 52
+     *
+     * @return bool
+     *
+     */
     public function setOtherHealthcareProvider($value, int $position = 52)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Get ID (OBR.1)
+     *
+     * @param int $position Defaults to 1
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getID(int $position = 1)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Patient Class (OBR.2)
+     *
+     * @param int $position Defaults to 2
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getPatientClass(int $position = 2)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Assigned PatientLocation (OBR.3)
+     *
+     * @param int $position Defaults to 3
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getAssignedPatientLocation(int $position = 3)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Admission Type (OBR.4)
+     *
+     * @param int $position Defaults to 4
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getAdmissionType(int $position = 4)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Pre AdmitNumber (OBR.5)
+     *
+     * @param int $position Defaults to 5
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getPreAdmitNumber(int $position = 5)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Prior PatientLocation (OBR.6)
+     *
+     * @param int $position Defaults to 6
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getPriorPatientLocation(int $position = 6)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Attending Doctor (OBR.7)
+     *
+     * @param int $position Defaults to 7
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getAttendingDoctor(int $position = 7)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Referring Doctor (OBR.8)
+     *
+     * @param int $position Defaults to 8
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getReferringDoctor(int $position = 8)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Consulting Doctor (OBR.9)
+     *
+     * @param int $position Defaults to 9
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getConsultingDoctor(int $position = 9)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Hospital Service (OBR.10)
+     *
+     * @param int $position Defaults to 10
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getHospitalService(int $position = 10)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Temporary Location (OBR.11)
+     *
+     * @param int $position Defaults to 11
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getTemporaryLocation(int $position = 11)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Pre AdmitTestIndicator (OBR.12)
+     *
+     * @param int $position Defaults to 12
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getPreAdmitTestIndicator(int $position = 12)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Re AdmissionIndicator (OBR.13)
+     *
+     * @param int $position Defaults to 13
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getReAdmissionIndicator(int $position = 13)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Admit Source (OBR.14)
+     *
+     * @param int $position Defaults to 14
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getAdmitSource(int $position = 14)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Ambulatory Status (OBR.15)
+     *
+     * @param int $position Defaults to 15
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getAmbulatoryStatus(int $position = 15)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Vip Indicator (OBR.16)
+     *
+     * @param int $position Defaults to 16
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getVipIndicator(int $position = 16)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Admitting Doctor (OBR.17)
+     *
+     * @param int $position Defaults to 17
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getAdmittingDoctor(int $position = 17)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Patient Type (OBR.18)
+     *
+     * @param int $position Defaults to 18
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getPatientType(int $position = 18)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Visit Number (OBR.19)
+     *
+     * @param int $position Defaults to 19
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getVisitNumber(int $position = 19)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Financial Class (OBR.20)
+     *
+     * @param int $position Defaults to 20
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getFinancialClass(int $position = 20)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Charge PriceIndicator (OBR.21)
+     *
+     * @param int $position Defaults to 21
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getChargePriceIndicator(int $position = 21)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Courtesy Code (OBR.22)
+     *
+     * @param int $position Defaults to 22
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getCourtesyCode(int $position = 22)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Credit Rating (OBR.23)
+     *
+     * @param int $position Defaults to 23
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getCreditRating(int $position = 23)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Contract Code (OBR.24)
+     *
+     * @param int $position Defaults to 24
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getContractCode(int $position = 24)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Contract EffectiveDate (OBR.25)
+     *
+     * @param int $position Defaults to 25
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getContractEffectiveDate(int $position = 25)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Contract Amount (OBR.26)
+     *
+     * @param int $position Defaults to 26
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getContractAmount(int $position = 26)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Contract Period (OBR.27)
+     *
+     * @param int $position Defaults to 27
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getContractPeriod(int $position = 27)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Interest Code (OBR.28)
+     *
+     * @param int $position Defaults to 28
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getInterestCode(int $position = 28)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Transfer ToBadDebtCode (OBR.29)
+     *
+     * @param int $position Defaults to 29
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getTransferToBadDebtCode(int $position = 29)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Transfer ToBadDebtDate (OBR.30)
+     *
+     * @param int $position Defaults to 30
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getTransferToBadDebtDate(int $position = 30)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Bad DebtAgencyCode (OBR.31)
+     *
+     * @param int $position Defaults to 31
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getBadDebtAgencyCode(int $position = 31)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Bad DebtTransferAmount (OBR.32)
+     *
+     * @param int $position Defaults to 32
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getBadDebtTransferAmount(int $position = 32)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Bad DebtRecoveryAmount (OBR.33)
+     *
+     * @param int $position Defaults to 33
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getBadDebtRecoveryAmount(int $position = 33)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Delete AccountIndicator (OBR.34)
+     *
+     * @param int $position Defaults to 34
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getDeleteAccountIndicator(int $position = 34)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Delete AccountDate (OBR.35)
+     *
+     * @param int $position Defaults to 35
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getDeleteAccountDate(int $position = 35)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Discharge Disposition (OBR.36)
+     *
+     * @param int $position Defaults to 36
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getDischargeDisposition(int $position = 36)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Discharged ToLocation (OBR.37)
+     *
+     * @param int $position Defaults to 37
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getDischargedToLocation(int $position = 37)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Diet Type (OBR.38)
+     *
+     * @param int $position Defaults to 38
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getDietType(int $position = 38)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Servicing Facility (OBR.39)
+     *
+     * @param int $position Defaults to 39
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getServicingFacility(int $position = 39)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Bed Status (OBR.40)
+     *
+     * @param int $position Defaults to 40
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getBedStatus(int $position = 40)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Account Status (OBR.41)
+     *
+     * @param int $position Defaults to 41
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getAccountStatus(int $position = 41)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Pending Location (OBR.42)
+     *
+     * @param int $position Defaults to 42
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getPendingLocation(int $position = 42)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Prior TemporaryLocation (OBR.43)
+     *
+     * @param int $position Defaults to 43
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getPriorTemporaryLocation(int $position = 43)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Admit DateTime (OBR.44)
+     *
+     * @param int $position Defaults to 44
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getAdmitDateTime(int $position = 44)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Discharge DateTime (OBR.45)
+     *
+     * @param int $position Defaults to 45
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getDischargeDateTime(int $position = 45)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Current PatientBalance (OBR.46)
+     *
+     * @param int $position Defaults to 46
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getCurrentPatientBalance(int $position = 46)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Total Charges (OBR.47)
+     *
+     * @param int $position Defaults to 47
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getTotalCharges(int $position = 47)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Total Adjustments (OBR.48)
+     *
+     * @param int $position Defaults to 48
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getTotalAdjustments(int $position = 48)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Total Payments (OBR.49)
+     *
+     * @param int $position Defaults to 49
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getTotalPayments(int $position = 49)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Alternate VisitID (OBR.50)
+     *
+     * @param int $position Defaults to 50
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getAlternateVisitID(int $position = 50)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Visit Indicator (OBR.51)
+     *
+     * @param int $position Defaults to 51
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getVisitIndicator(int $position = 51)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Other HealthcareProvider (OBR.52)
+     *
+     * @param int $position Defaults to 52
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getOtherHealthcareProvider(int $position = 52)
     {
         return $this->getField($position);

--- a/src/HL7/Segments/PV2.php
+++ b/src/HL7/Segments/PV2.php
@@ -23,6 +23,15 @@ class PV2 extends Segment
     /**
      * @return bool
      */
+    /**
+     * Set Prior PendingLocation (OBR.1)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 1
+     *
+     * @return bool
+     *
+     */
     public function setPriorPendingLocation($value, int $position = 1)
     {
         return $this->setField($position, $value);
@@ -30,6 +39,15 @@ class PV2 extends Segment
 
     /**
      * @return bool
+     */
+    /**
+     * Set Accommodation Code (OBR.2)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 2
+     *
+     * @return bool
+     *
      */
     public function setAccommodationCode($value, int $position = 2)
     {
@@ -39,6 +57,15 @@ class PV2 extends Segment
     /**
      * @return bool
      */
+    /**
+     * Set Admit Reason (OBR.3)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 3
+     *
+     * @return bool
+     *
+     */
     public function setAdmitReason($value, int $position = 3)
     {
         return $this->setField($position, $value);
@@ -46,6 +73,15 @@ class PV2 extends Segment
 
     /**
      * @return bool
+     */
+    /**
+     * Set Transfer Reason (OBR.4)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 4
+     *
+     * @return bool
+     *
      */
     public function setTransferReason($value, int $position = 4)
     {
@@ -55,6 +91,15 @@ class PV2 extends Segment
     /**
      * @return bool
      */
+    /**
+     * Set Patient Valuables (OBR.5)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 5
+     *
+     * @return bool
+     *
+     */
     public function setPatientValuables($value, int $position = 5)
     {
         return $this->setField($position, $value);
@@ -62,6 +107,15 @@ class PV2 extends Segment
 
     /**
      * @return bool
+     */
+    /**
+     * Set Patient ValuablesLocation (OBR.6)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 6
+     *
+     * @return bool
+     *
      */
     public function setPatientValuablesLocation($value, int $position = 6)
     {
@@ -71,6 +125,15 @@ class PV2 extends Segment
     /**
      * @return bool
      */
+    /**
+     * Set Visit UserCode (OBR.7)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 7
+     *
+     * @return bool
+     *
+     */
     public function setVisitUserCode($value, int $position = 7)
     {
         return $this->setField($position, $value);
@@ -78,6 +141,15 @@ class PV2 extends Segment
 
     /**
      * @return bool
+     */
+    /**
+     * Set Expected AdmitDateTime (OBR.8)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 8
+     *
+     * @return bool
+     *
      */
     public function setExpectedAdmitDateTime($value, int $position = 8)
     {
@@ -87,6 +159,15 @@ class PV2 extends Segment
     /**
      * @return bool
      */
+    /**
+     * Set Expected DischargeDateTime (OBR.9)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 9
+     *
+     * @return bool
+     *
+     */
     public function setExpectedDischargeDateTime($value, int $position = 9)
     {
         return $this->setField($position, $value);
@@ -94,6 +175,15 @@ class PV2 extends Segment
 
     /**
      * @return bool
+     */
+    /**
+     * Set Estimated LengthofInpatientStay (OBR.10)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 10
+     *
+     * @return bool
+     *
      */
     public function setEstimatedLengthofInpatientStay($value, int $position = 10)
     {
@@ -103,6 +193,15 @@ class PV2 extends Segment
     /**
      * @return bool
      */
+    /**
+     * Set Actual LengthOfInpatientStay (OBR.11)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 11
+     *
+     * @return bool
+     *
+     */
     public function setActualLengthOfInpatientStay($value, int $position = 11)
     {
         return $this->setField($position, $value);
@@ -110,6 +209,15 @@ class PV2 extends Segment
 
     /**
      * @return bool
+     */
+    /**
+     * Set Visit Description (OBR.12)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 12
+     *
+     * @return bool
+     *
      */
     public function setVisitDescription($value, int $position = 12)
     {
@@ -119,6 +227,15 @@ class PV2 extends Segment
     /**
      * @return bool
      */
+    /**
+     * Set Referral SourceCode (OBR.13)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 13
+     *
+     * @return bool
+     *
+     */
     public function setReferralSourceCode($value, int $position = 13)
     {
         return $this->setField($position, $value);
@@ -126,6 +243,15 @@ class PV2 extends Segment
 
     /**
      * @return bool
+     */
+    /**
+     * Set Previous ServiceDate (OBR.14)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 14
+     *
+     * @return bool
+     *
      */
     public function setPreviousServiceDate($value, int $position = 14)
     {
@@ -135,6 +261,15 @@ class PV2 extends Segment
     /**
      * @return bool
      */
+    /**
+     * Set Employment IllnessRelatedIndicator (OBR.15)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 15
+     *
+     * @return bool
+     *
+     */
     public function setEmploymentIllnessRelatedIndicator($value, int $position = 15)
     {
         return $this->setField($position, $value);
@@ -142,6 +277,15 @@ class PV2 extends Segment
 
     /**
      * @return bool
+     */
+    /**
+     * Set Purge StatusCode (OBR.16)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 16
+     *
+     * @return bool
+     *
      */
     public function setPurgeStatusCode($value, int $position = 16)
     {
@@ -151,6 +295,15 @@ class PV2 extends Segment
     /**
      * @return bool
      */
+    /**
+     * Set Purge StatusDate (OBR.17)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 17
+     *
+     * @return bool
+     *
+     */
     public function setPurgeStatusDate($value, int $position = 17)
     {
         return $this->setField($position, $value);
@@ -158,6 +311,15 @@ class PV2 extends Segment
 
     /**
      * @return bool
+     */
+    /**
+     * Set Special ProgramCode (OBR.18)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 18
+     *
+     * @return bool
+     *
      */
     public function setSpecialProgramCode($value, int $position = 18)
     {
@@ -167,6 +329,15 @@ class PV2 extends Segment
     /**
      * @return bool
      */
+    /**
+     * Set Retention Indicator (OBR.19)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 19
+     *
+     * @return bool
+     *
+     */
     public function setRetentionIndicator($value, int $position = 19)
     {
         return $this->setField($position, $value);
@@ -174,6 +345,15 @@ class PV2 extends Segment
 
     /**
      * @return bool
+     */
+    /**
+     * Set Expected NumberOfInsurancePlans (OBR.20)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 20
+     *
+     * @return bool
+     *
      */
     public function setExpectedNumberOfInsurancePlans($value, int $position = 20)
     {
@@ -183,6 +363,15 @@ class PV2 extends Segment
     /**
      * @return bool
      */
+    /**
+     * Set Visit PublicityCode (OBR.21)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 21
+     *
+     * @return bool
+     *
+     */
     public function setVisitPublicityCode($value, int $position = 21)
     {
         return $this->setField($position, $value);
@@ -190,6 +379,15 @@ class PV2 extends Segment
 
     /**
      * @return bool
+     */
+    /**
+     * Set Visit ProtectionIndicator (OBR.22)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 22
+     *
+     * @return bool
+     *
      */
     public function setVisitProtectionIndicator($value, int $position = 22)
     {
@@ -199,6 +397,15 @@ class PV2 extends Segment
     /**
      * @return bool
      */
+    /**
+     * Set Clinic OrganizationName (OBR.23)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 23
+     *
+     * @return bool
+     *
+     */
     public function setClinicOrganizationName($value, int $position = 23)
     {
         return $this->setField($position, $value);
@@ -206,6 +413,15 @@ class PV2 extends Segment
 
     /**
      * @return bool
+     */
+    /**
+     * Set Patient StatusCode (OBR.24)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 24
+     *
+     * @return bool
+     *
      */
     public function setPatientStatusCode($value, int $position = 24)
     {
@@ -215,6 +431,15 @@ class PV2 extends Segment
     /**
      * @return bool
      */
+    /**
+     * Set Visit PriorityCode (OBR.25)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 25
+     *
+     * @return bool
+     *
+     */
     public function setVisitPriorityCode($value, int $position = 25)
     {
         return $this->setField($position, $value);
@@ -222,6 +447,15 @@ class PV2 extends Segment
 
     /**
      * @return bool
+     */
+    /**
+     * Set Previous TreatmentDate (OBR.26)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 26
+     *
+     * @return bool
+     *
      */
     public function setPreviousTreatmentDate($value, int $position = 26)
     {
@@ -231,6 +465,15 @@ class PV2 extends Segment
     /**
      * @return bool
      */
+    /**
+     * Set Expected DischargeDisposition (OBR.27)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 27
+     *
+     * @return bool
+     *
+     */
     public function setExpectedDischargeDisposition($value, int $position = 27)
     {
         return $this->setField($position, $value);
@@ -238,6 +481,15 @@ class PV2 extends Segment
 
     /**
      * @return bool
+     */
+    /**
+     * Set Signature OnFileDate (OBR.28)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 28
+     *
+     * @return bool
+     *
      */
     public function setSignatureOnFileDate($value, int $position = 28)
     {
@@ -247,6 +499,15 @@ class PV2 extends Segment
     /**
      * @return bool
      */
+    /**
+     * Set First SimilarIllnessDate (OBR.29)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 29
+     *
+     * @return bool
+     *
+     */
     public function setFirstSimilarIllnessDate($value, int $position = 29)
     {
         return $this->setField($position, $value);
@@ -254,6 +515,15 @@ class PV2 extends Segment
 
     /**
      * @return bool
+     */
+    /**
+     * Set Patient ChargeAdjustmentCode (OBR.30)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 30
+     *
+     * @return bool
+     *
      */
     public function setPatientChargeAdjustmentCode($value, int $position = 30)
     {
@@ -263,6 +533,15 @@ class PV2 extends Segment
     /**
      * @return bool
      */
+    /**
+     * Set Recurring ServiceCode (OBR.31)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 31
+     *
+     * @return bool
+     *
+     */
     public function setRecurringServiceCode($value, int $position = 31)
     {
         return $this->setField($position, $value);
@@ -270,6 +549,15 @@ class PV2 extends Segment
 
     /**
      * @return bool
+     */
+    /**
+     * Set Billing MediaCode (OBR.32)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 32
+     *
+     * @return bool
+     *
      */
     public function setBillingMediaCode($value, int $position = 32)
     {
@@ -279,6 +567,15 @@ class PV2 extends Segment
     /**
      * @return bool
      */
+    /**
+     * Set Expected SurgeryDateAndTime (OBR.33)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 33
+     *
+     * @return bool
+     *
+     */
     public function setExpectedSurgeryDateAndTime($value, int $position = 33)
     {
         return $this->setField($position, $value);
@@ -286,6 +583,15 @@ class PV2 extends Segment
 
     /**
      * @return bool
+     */
+    /**
+     * Set Military PartnershipCode (OBR.34)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 34
+     *
+     * @return bool
+     *
      */
     public function setMilitaryPartnershipCode($value, int $position = 34)
     {
@@ -295,6 +601,15 @@ class PV2 extends Segment
     /**
      * @return bool
      */
+    /**
+     * Set Military NonAvailabilityCode (OBR.35)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 35
+     *
+     * @return bool
+     *
+     */
     public function setMilitaryNonAvailabilityCode($value, int $position = 35)
     {
         return $this->setField($position, $value);
@@ -302,6 +617,15 @@ class PV2 extends Segment
 
     /**
      * @return bool
+     */
+    /**
+     * Set Newborn BabyIndicator (OBR.36)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 36
+     *
+     * @return bool
+     *
      */
     public function setNewbornBabyIndicator($value, int $position = 36)
     {
@@ -311,6 +635,15 @@ class PV2 extends Segment
     /**
      * @return bool
      */
+    /**
+     * Set Baby DetainedIndicator (OBR.37)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 37
+     *
+     * @return bool
+     *
+     */
     public function setBabyDetainedIndicator($value, int $position = 37)
     {
         return $this->setField($position, $value);
@@ -318,6 +651,15 @@ class PV2 extends Segment
 
     /**
      * @return bool
+     */
+    /**
+     * Set Mode OfArrivalCode (OBR.38)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 38
+     *
+     * @return bool
+     *
      */
     public function setModeOfArrivalCode($value, int $position = 38)
     {
@@ -327,6 +669,15 @@ class PV2 extends Segment
     /**
      * @return bool
      */
+    /**
+     * Set Recreational DrugUseCode (OBR.39)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 39
+     *
+     * @return bool
+     *
+     */
     public function setRecreationalDrugUseCode($value, int $position = 39)
     {
         return $this->setField($position, $value);
@@ -334,6 +685,15 @@ class PV2 extends Segment
 
     /**
      * @return bool
+     */
+    /**
+     * Set Admission LevelOfCareCode (OBR.40)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 40
+     *
+     * @return bool
+     *
      */
     public function setAdmissionLevelOfCareCode($value, int $position = 40)
     {
@@ -343,6 +703,15 @@ class PV2 extends Segment
     /**
      * @return bool
      */
+    /**
+     * Set Precaution Code (OBR.41)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 41
+     *
+     * @return bool
+     *
+     */
     public function setPrecautionCode($value, int $position = 41)
     {
         return $this->setField($position, $value);
@@ -350,6 +719,15 @@ class PV2 extends Segment
 
     /**
      * @return bool
+     */
+    /**
+     * Set Patient ConditionCode (OBR.42)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 42
+     *
+     * @return bool
+     *
      */
     public function setPatientConditionCode($value, int $position = 42)
     {
@@ -359,6 +737,15 @@ class PV2 extends Segment
     /**
      * @return bool
      */
+    /**
+     * Set Living WillCode (OBR.43)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 43
+     *
+     * @return bool
+     *
+     */
     public function setLivingWillCode($value, int $position = 43)
     {
         return $this->setField($position, $value);
@@ -366,6 +753,15 @@ class PV2 extends Segment
 
     /**
      * @return bool
+     */
+    /**
+     * Set Organ DonorCode (OBR.44)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 44
+     *
+     * @return bool
+     *
      */
     public function setOrganDonorCode($value, int $position = 44)
     {
@@ -375,6 +771,15 @@ class PV2 extends Segment
     /**
      * @return bool
      */
+    /**
+     * Set Advance DirectiveCode (OBR.45)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 45
+     *
+     * @return bool
+     *
+     */
     public function setAdvanceDirectiveCode($value, int $position = 45)
     {
         return $this->setField($position, $value);
@@ -382,6 +787,15 @@ class PV2 extends Segment
 
     /**
      * @return bool
+     */
+    /**
+     * Set Patient StatusEffectiveDate (OBR.46)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 46
+     *
+     * @return bool
+     *
      */
     public function setPatientStatusEffectiveDate($value, int $position = 46)
     {
@@ -391,6 +805,15 @@ class PV2 extends Segment
     /**
      * @return bool
      */
+    /**
+     * Set Expected LOAReturnDateTime (OBR.47)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 47
+     *
+     * @return bool
+     *
+     */
     public function setExpectedLOAReturnDateTime($value, int $position = 47)
     {
         return $this->setField($position, $value);
@@ -398,231 +821,599 @@ class PV2 extends Segment
 
     // -------------------- Getter Methods ------------------------------
 
+    /**
+     * Get Accommodation Code (OBR.2)
+     *
+     * @param int $position Defaults to 2
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getAccommodationCode(int $position = 2)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Admit Reason (OBR.3)
+     *
+     * @param int $position Defaults to 3
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getAdmitReason(int $position = 3)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Transfer Reason (OBR.4)
+     *
+     * @param int $position Defaults to 4
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getTransferReason(int $position = 4)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Patient Valuables (OBR.5)
+     *
+     * @param int $position Defaults to 5
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getPatientValuables(int $position = 5)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Patient ValuablesLocation (OBR.6)
+     *
+     * @param int $position Defaults to 6
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getPatientValuablesLocation(int $position = 6)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Visit UserCode (OBR.7)
+     *
+     * @param int $position Defaults to 7
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getVisitUserCode(int $position = 7)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Expected AdmitDateTime (OBR.8)
+     *
+     * @param int $position Defaults to 8
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getExpectedAdmitDateTime(int $position = 8)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Expected DischargeDateTime (OBR.9)
+     *
+     * @param int $position Defaults to 9
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getExpectedDischargeDateTime(int $position = 9)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Estimated LengthofInpatientStay (OBR.10)
+     *
+     * @param int $position Defaults to 10
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getEstimatedLengthofInpatientStay(int $position = 10)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Actual LengthOfInpatientStay (OBR.11)
+     *
+     * @param int $position Defaults to 11
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getActualLengthOfInpatientStay(int $position = 11)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Visit Description (OBR.12)
+     *
+     * @param int $position Defaults to 12
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getVisitDescription(int $position = 12)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Referral SourceCode (OBR.13)
+     *
+     * @param int $position Defaults to 13
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getReferralSourceCode(int $position = 13)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Previous ServiceDate (OBR.14)
+     *
+     * @param int $position Defaults to 14
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getPreviousServiceDate(int $position = 14)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Employment IllnessRelatedIndicator (OBR.15)
+     *
+     * @param int $position Defaults to 15
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getEmploymentIllnessRelatedIndicator(int $position = 15)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Purge StatusCode (OBR.16)
+     *
+     * @param int $position Defaults to 16
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getPurgeStatusCode(int $position = 16)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Purge StatusDate (OBR.17)
+     *
+     * @param int $position Defaults to 17
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getPurgeStatusDate(int $position = 17)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Special ProgramCode (OBR.18)
+     *
+     * @param int $position Defaults to 18
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getSpecialProgramCode(int $position = 18)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Retention Indicator (OBR.19)
+     *
+     * @param int $position Defaults to 19
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getRetentionIndicator(int $position = 19)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Expected NumberOfInsurancePlans (OBR.20)
+     *
+     * @param int $position Defaults to 20
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getExpectedNumberOfInsurancePlans(int $position = 20)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Visit PublicityCode (OBR.21)
+     *
+     * @param int $position Defaults to 21
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getVisitPublicityCode(int $position = 21)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Visit ProtectionIndicator (OBR.22)
+     *
+     * @param int $position Defaults to 22
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getVisitProtectionIndicator(int $position = 22)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Clinic OrganizationName (OBR.23)
+     *
+     * @param int $position Defaults to 23
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getClinicOrganizationName(int $position = 23)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Patient StatusCode (OBR.24)
+     *
+     * @param int $position Defaults to 24
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getPatientStatusCode(int $position = 24)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Visit PriorityCode (OBR.25)
+     *
+     * @param int $position Defaults to 25
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getVisitPriorityCode(int $position = 25)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Previous TreatmentDate (OBR.26)
+     *
+     * @param int $position Defaults to 26
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getPreviousTreatmentDate(int $position = 26)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Expected DischargeDisposition (OBR.27)
+     *
+     * @param int $position Defaults to 27
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getExpectedDischargeDisposition(int $position = 27)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Signature OnFileDate (OBR.28)
+     *
+     * @param int $position Defaults to 28
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getSignatureOnFileDate(int $position = 28)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get First SimilarIllnessDate (OBR.29)
+     *
+     * @param int $position Defaults to 29
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getFirstSimilarIllnessDate(int $position = 29)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Patient ChargeAdjustmentCode (OBR.30)
+     *
+     * @param int $position Defaults to 30
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getPatientChargeAdjustmentCode(int $position = 30)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Recurring ServiceCode (OBR.31)
+     *
+     * @param int $position Defaults to 31
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getRecurringServiceCode(int $position = 31)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Billing MediaCode (OBR.32)
+     *
+     * @param int $position Defaults to 32
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getBillingMediaCode(int $position = 32)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Expected SurgeryDateAndTime (OBR.33)
+     *
+     * @param int $position Defaults to 33
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getExpectedSurgeryDateAndTime(int $position = 33)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Military PartnershipCode (OBR.34)
+     *
+     * @param int $position Defaults to 34
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getMilitaryPartnershipCode(int $position = 34)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Military NonAvailabilityCode (OBR.35)
+     *
+     * @param int $position Defaults to 35
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getMilitaryNonAvailabilityCode(int $position = 35)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Newborn BabyIndicator (OBR.36)
+     *
+     * @param int $position Defaults to 36
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getNewbornBabyIndicator(int $position = 36)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Baby DetainedIndicator (OBR.37)
+     *
+     * @param int $position Defaults to 37
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getBabyDetainedIndicator(int $position = 37)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Mode OfArrivalCode (OBR.38)
+     *
+     * @param int $position Defaults to 38
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getModeOfArrivalCode(int $position = 38)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Recreational DrugUseCode (OBR.39)
+     *
+     * @param int $position Defaults to 39
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getRecreationalDrugUseCode(int $position = 39)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Admission LevelOfCareCode (OBR.40)
+     *
+     * @param int $position Defaults to 40
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getAdmissionLevelOfCareCode(int $position = 40)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Precaution Code (OBR.41)
+     *
+     * @param int $position Defaults to 41
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getPrecautionCode(int $position = 41)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Patient ConditionCode (OBR.42)
+     *
+     * @param int $position Defaults to 42
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getPatientConditionCode(int $position = 42)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Living WillCode (OBR.43)
+     *
+     * @param int $position Defaults to 43
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getLivingWillCode(int $position = 43)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Organ DonorCode (OBR.44)
+     *
+     * @param int $position Defaults to 44
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getOrganDonorCode(int $position = 44)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Advance DirectiveCode (OBR.45)
+     *
+     * @param int $position Defaults to 45
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getAdvanceDirectiveCode(int $position = 45)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Patient StatusEffectiveDate (OBR.46)
+     *
+     * @param int $position Defaults to 46
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getPatientStatusEffectiveDate(int $position = 46)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Expected LOAReturnDateTime (OBR.47)
+     *
+     * @param int $position Defaults to 47
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getExpectedLOAReturnDateTime(int $position = 47)
     {
         return $this->getField($position);

--- a/src/HL7/Segments/RGS.php
+++ b/src/HL7/Segments/RGS.php
@@ -43,26 +43,68 @@ class RGS extends Segment
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Segment ActionCode (OBR.2)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 2
+     *
+     * @return bool
+     *
+     */
     public function setSegmentActionCode($value, int $position = 2): bool
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Resource GroupID (OBR.3)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 3
+     *
+     * @return bool
+     *
+     */
     public function setResourceGroupID($value, int $position = 3): bool
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Get ID (OBR.1)
+     *
+     * @param int $position Defaults to 1
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getID(int $position = 1)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Segment ActionCode (OBR.2)
+     *
+     * @param int $position Defaults to 2
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getSegmentActionCode(int $position = 2)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Resource GroupID (OBR.3)
+     *
+     * @param int $position Defaults to 3
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getResourceGroupID(int $position = 3)
     {
         return $this->getField($position);

--- a/src/HL7/Segments/SAC.php
+++ b/src/HL7/Segments/SAC.php
@@ -36,31 +36,85 @@ class SAC extends Segment
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Accession Identifier (OBR.2)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 2
+     *
+     * @return bool
+     *
+     */
     public function setAccessionIdentifier($value, int $position = 2)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Container Identifier (OBR.3)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 3
+     *
+     * @return bool
+     *
+     */
     public function setContainerIdentifier($value, int $position = 3)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Primary ContainerIdentifier (OBR.4)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 4
+     *
+     * @return bool
+     *
+     */
     public function setPrimaryContainerIdentifier($value, int $position = 4)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Equipment ContainerIdentifier (OBR.5)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 5
+     *
+     * @return bool
+     *
+     */
     public function setEquipmentContainerIdentifier($value, int $position = 5)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Specimen Source (OBR.6)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 6
+     *
+     * @return bool
+     *
+     */
     public function setSpecimenSource($value, int $position = 6)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Registration DateTime (OBR.7)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 7
+     *
+     * @return bool
+     *
+     */
     public function setRegistrationDateTime($value, int $position = 7)
     {
         return $this->setField($position, $value);
@@ -79,406 +133,1091 @@ class SAC extends Segment
      * X : Container Unavailable
      * U : Unknown
      */
+    /**
+     * Set Container Status (OBR.8)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 8
+     *
+     * @return bool
+     *
+     */
     public function setContainerStatus($value, int $position = 8)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Carrier Type (OBR.9)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 9
+     *
+     * @return bool
+     *
+     */
     public function setCarrierType($value, int $position = 9)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Carrier Identifier (OBR.10)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 10
+     *
+     * @return bool
+     *
+     */
     public function setCarrierIdentifier($value, int $position = 10)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Position InCarrier (OBR.11)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 11
+     *
+     * @return bool
+     *
+     */
     public function setPositionInCarrier($value, int $position = 11)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Tray TypeSAC (OBR.12)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 12
+     *
+     * @return bool
+     *
+     */
     public function setTrayTypeSAC($value, int $position = 12)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Tray Identifier (OBR.13)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 13
+     *
+     * @return bool
+     *
+     */
     public function setTrayIdentifier($value, int $position = 13)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Position InTray (OBR.14)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 14
+     *
+     * @return bool
+     *
+     */
     public function setPositionInTray($value, int $position = 14)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Location (OBR.15)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 15
+     *
+     * @return bool
+     *
+     */
     public function setLocation($value, int $position = 15)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Container Height (OBR.16)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 16
+     *
+     * @return bool
+     *
+     */
     public function setContainerHeight($value, int $position = 16)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Container Diameter (OBR.17)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 17
+     *
+     * @return bool
+     *
+     */
     public function setContainerDiameter($value, int $position = 17)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Barrier Delta (OBR.18)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 18
+     *
+     * @return bool
+     *
+     */
     public function setBarrierDelta($value, int $position = 18)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Bottom Delta (OBR.19)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 19
+     *
+     * @return bool
+     *
+     */
     public function setBottomDelta($value, int $position = 19)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Container SizeUnits (OBR.20)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 20
+     *
+     * @return bool
+     *
+     */
     public function setContainerSizeUnits($value, int $position = 20)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Container Volume (OBR.21)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 21
+     *
+     * @return bool
+     *
+     */
     public function setContainerVolume($value, int $position = 21)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Available SpecimenVolume (OBR.22)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 22
+     *
+     * @return bool
+     *
+     */
     public function setAvailableSpecimenVolume($value, int $position = 22)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Initial SpecimenVolume (OBR.23)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 23
+     *
+     * @return bool
+     *
+     */
     public function setInitialSpecimenVolume($value, int $position = 23)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Volume Units (OBR.24)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 24
+     *
+     * @return bool
+     *
+     */
     public function setVolumeUnits($value, int $position = 24)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Separator Type (OBR.25)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 25
+     *
+     * @return bool
+     *
+     */
     public function setSeparatorType($value, int $position = 25)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Cap Type (OBR.26)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 26
+     *
+     * @return bool
+     *
+     */
     public function setCapType($value, int $position = 26)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Additive (OBR.27)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 27
+     *
+     * @return bool
+     *
+     */
     public function setAdditive($value, int $position = 27)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Specimen Component (OBR.28)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 28
+     *
+     * @return bool
+     *
+     */
     public function setSpecimenComponent($value, int $position = 28)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Dilution Factor (OBR.29)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 29
+     *
+     * @return bool
+     *
+     */
     public function setDilutionFactor($value, int $position = 29)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Treatment (OBR.30)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 30
+     *
+     * @return bool
+     *
+     */
     public function setTreatment($value, int $position = 30)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Temperature (OBR.31)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 31
+     *
+     * @return bool
+     *
+     */
     public function setTemperature($value, int $position = 31)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Hemolysis Index (OBR.32)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 32
+     *
+     * @return bool
+     *
+     */
     public function setHemolysisIndex($value, int $position = 32)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Hemolysis IndexUnits (OBR.33)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 33
+     *
+     * @return bool
+     *
+     */
     public function setHemolysisIndexUnits($value, int $position = 33)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Lepemia Index (OBR.34)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 34
+     *
+     * @return bool
+     *
+     */
     public function setLepemiaIndex($value, int $position = 34)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Lepemia IndexUnits (OBR.35)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 35
+     *
+     * @return bool
+     *
+     */
     public function setLepemiaIndexUnits($value, int $position = 35)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Icterus Index (OBR.36)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 36
+     *
+     * @return bool
+     *
+     */
     public function setIcterusIndex($value, int $position = 36)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Icterus IndexUnits (OBR.37)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 37
+     *
+     * @return bool
+     *
+     */
     public function setIcterusIndexUnits($value, int $position = 37)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Fibrin Index (OBR.38)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 38
+     *
+     * @return bool
+     *
+     */
     public function setFibrinIndex($value, int $position = 38)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Fibrin IndexUnits (OBR.39)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 39
+     *
+     * @return bool
+     *
+     */
     public function setFibrinIndexUnits($value, int $position = 39)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set System InducedContaminants (OBR.40)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 40
+     *
+     * @return bool
+     *
+     */
     public function setSystemInducedContaminants($value, int $position = 40)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Drug Interference (OBR.41)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 41
+     *
+     * @return bool
+     *
+     */
     public function setDrugInterference($value, int $position = 41)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Artificial Blood (OBR.42)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 42
+     *
+     * @return bool
+     *
+     */
     public function setArtificialBlood($value, int $position = 42)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Special HandlingCode (OBR.43)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 43
+     *
+     * @return bool
+     *
+     */
     public function setSpecialHandlingCode($value, int $position = 43)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Other EnvironmentalFactors (OBR.44)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 44
+     *
+     * @return bool
+     *
+     */
     public function setOtherEnvironmentalFactors($value, int $position = 44)
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Get External AccessionIdentifier (OBR.1)
+     *
+     * @param int $position Defaults to 1
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getExternalAccessionIdentifier(int $position = 1)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Accession Identifier (OBR.2)
+     *
+     * @param int $position Defaults to 2
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getAccessionIdentifier(int $position = 2)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Container Identifier (OBR.3)
+     *
+     * @param int $position Defaults to 3
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getContainerIdentifier(int $position = 3)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Primary ContainerIdentifier (OBR.4)
+     *
+     * @param int $position Defaults to 4
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getPrimaryContainerIdentifier(int $position = 4)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Equipment ContainerIdentifier (OBR.5)
+     *
+     * @param int $position Defaults to 5
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getEquipmentContainerIdentifier(int $position = 5)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Specimen Source (OBR.6)
+     *
+     * @param int $position Defaults to 6
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getSpecimenSource(int $position = 6)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Registration DateTime (OBR.7)
+     *
+     * @param int $position Defaults to 7
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getRegistrationDateTime(int $position = 7)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Container Status (OBR.8)
+     *
+     * @param int $position Defaults to 8
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getContainerStatus(int $position = 8)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Carrier Type (OBR.9)
+     *
+     * @param int $position Defaults to 9
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getCarrierType(int $position = 9)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Carrier Identifier (OBR.10)
+     *
+     * @param int $position Defaults to 10
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getCarrierIdentifier(int $position = 10)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Position InCarrier (OBR.11)
+     *
+     * @param int $position Defaults to 11
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getPositionInCarrier(int $position = 11)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Tray TypeSAC (OBR.12)
+     *
+     * @param int $position Defaults to 12
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getTrayTypeSAC(int $position = 12)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Tray Identifier (OBR.13)
+     *
+     * @param int $position Defaults to 13
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getTrayIdentifier(int $position = 13)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Position InTray (OBR.14)
+     *
+     * @param int $position Defaults to 14
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getPositionInTray(int $position = 14)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Location (OBR.15)
+     *
+     * @param int $position Defaults to 15
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getLocation(int $position = 15)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Container Height (OBR.16)
+     *
+     * @param int $position Defaults to 16
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getContainerHeight(int $position = 16)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Container Diameter (OBR.17)
+     *
+     * @param int $position Defaults to 17
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getContainerDiameter(int $position = 17)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Barrier Delta (OBR.18)
+     *
+     * @param int $position Defaults to 18
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getBarrierDelta(int $position = 18)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Bottom Delta (OBR.19)
+     *
+     * @param int $position Defaults to 19
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getBottomDelta(int $position = 19)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Container SizeUnits (OBR.20)
+     *
+     * @param int $position Defaults to 20
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getContainerSizeUnits(int $position = 20)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Container Volume (OBR.21)
+     *
+     * @param int $position Defaults to 21
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getContainerVolume(int $position = 21)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Available SpecimenVolume (OBR.22)
+     *
+     * @param int $position Defaults to 22
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getAvailableSpecimenVolume(int $position = 22)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Initial SpecimenVolume (OBR.23)
+     *
+     * @param int $position Defaults to 23
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getInitialSpecimenVolume(int $position = 23)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Volume Units (OBR.24)
+     *
+     * @param int $position Defaults to 24
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getVolumeUnits(int $position = 24)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Separator Type (OBR.25)
+     *
+     * @param int $position Defaults to 25
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getSeparatorType(int $position = 25)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Cap Type (OBR.26)
+     *
+     * @param int $position Defaults to 26
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getCapType(int $position = 26)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Additive (OBR.27)
+     *
+     * @param int $position Defaults to 27
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getAdditive(int $position = 27)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Specimen Component (OBR.28)
+     *
+     * @param int $position Defaults to 28
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getSpecimenComponent(int $position = 28)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Dilution Factor (OBR.29)
+     *
+     * @param int $position Defaults to 29
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getDilutionFactor(int $position = 29)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Treatment (OBR.30)
+     *
+     * @param int $position Defaults to 30
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getTreatment(int $position = 30)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Temperature (OBR.31)
+     *
+     * @param int $position Defaults to 31
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getTemperature(int $position = 31)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Hemolysis Index (OBR.32)
+     *
+     * @param int $position Defaults to 32
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getHemolysisIndex(int $position = 32)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Hemolysis IndexUnits (OBR.33)
+     *
+     * @param int $position Defaults to 33
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getHemolysisIndexUnits(int $position = 33)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Lepemia Index (OBR.34)
+     *
+     * @param int $position Defaults to 34
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getLepemiaIndex(int $position = 34)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Lepemia IndexUnits (OBR.35)
+     *
+     * @param int $position Defaults to 35
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getLepemiaIndexUnits(int $position = 35)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Icterus Index (OBR.36)
+     *
+     * @param int $position Defaults to 36
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getIcterusIndex(int $position = 36)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Icterus IndexUnits (OBR.37)
+     *
+     * @param int $position Defaults to 37
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getIcterusIndexUnits(int $position = 37)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Fibrin Index (OBR.38)
+     *
+     * @param int $position Defaults to 38
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getFibrinIndex(int $position = 38)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Fibrin IndexUnits (OBR.39)
+     *
+     * @param int $position Defaults to 39
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getFibrinIndexUnits(int $position = 39)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get System InducedContaminants (OBR.40)
+     *
+     * @param int $position Defaults to 40
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getSystemInducedContaminants(int $position = 40)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Drug Interference (OBR.41)
+     *
+     * @param int $position Defaults to 41
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getDrugInterference(int $position = 41)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Artificial Blood (OBR.42)
+     *
+     * @param int $position Defaults to 42
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getArtificialBlood(int $position = 42)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Special HandlingCode (OBR.43)
+     *
+     * @param int $position Defaults to 43
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getSpecialHandlingCode(int $position = 43)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Other EnvironmentalFactors (OBR.44)
+     *
+     * @param int $position Defaults to 44
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getOtherEnvironmentalFactors(int $position = 44)
     {
         return $this->getField($position);

--- a/src/HL7/Segments/SCH.php
+++ b/src/HL7/Segments/SCH.php
@@ -18,251 +18,676 @@ class SCH extends Segment
         parent::__construct('SCH', $fields);
     }
 
+    /**
+     * Set Placer AppointmentID (OBR.1)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 1
+     *
+     * @return bool
+     *
+     */
     public function setPlacerAppointmentID($value, int $position = 1): bool
     {
          return $this->setField($position, $value);
     }
 
+    /**
+     * Set Filler AppointmentID (OBR.2)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 2
+     *
+     * @return bool
+     *
+     */
     public function setFillerAppointmentID($value, int $position = 2): bool
     {
          return $this->setField($position, $value);
     }
 
+    /**
+     * Set Occurrence Number (OBR.3)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 3
+     *
+     * @return bool
+     *
+     */
     public function setOccurrenceNumber($value, int $position = 3): bool
     {
          return $this->setField($position, $value);
     }
 
+    /**
+     * Set Placer GroupNumber (OBR.4)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 4
+     *
+     * @return bool
+     *
+     */
     public function setPlacerGroupNumber($value, int $position = 4): bool
     {
          return $this->setField($position, $value);
     }
 
+    /**
+     * Set Schedule ID (OBR.5)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 5
+     *
+     * @return bool
+     *
+     */
     public function setScheduleID($value, int $position = 5): bool
     {
          return $this->setField($position, $value);
     }
 
+    /**
+     * Set Event Reason (OBR.6)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 6
+     *
+     * @return bool
+     *
+     */
     public function setEventReason($value, int $position = 6): bool
     {
          return $this->setField($position, $value);
     }
 
+    /**
+     * Set Appointment Reason (OBR.7)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 7
+     *
+     * @return bool
+     *
+     */
     public function setAppointmentReason($value, int $position = 7): bool
     {
          return $this->setField($position, $value);
     }
 
+    /**
+     * Set Appointment Type (OBR.8)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 8
+     *
+     * @return bool
+     *
+     */
     public function setAppointmentType($value, int $position = 8): bool
     {
          return $this->setField($position, $value);
     }
 
+    /**
+     * Set Appointment Duration (OBR.9)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 9
+     *
+     * @return bool
+     *
+     */
     public function setAppointmentDuration($value, int $position = 9): bool
     {
          return $this->setField($position, $value);
     }
 
+    /**
+     * Set Appointment DurationUnits (OBR.10)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 10
+     *
+     * @return bool
+     *
+     */
     public function setAppointmentDurationUnits($value, int $position = 10): bool
     {
          return $this->setField($position, $value);
     }
 
+    /**
+     * Set Appointment TimingQuantity (OBR.11)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 11
+     *
+     * @return bool
+     *
+     */
     public function setAppointmentTimingQuantity($value, int $position = 11): bool
     {
          return $this->setField($position, $value);
     }
 
+    /**
+     * Set Placer ContactPerson (OBR.12)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 12
+     *
+     * @return bool
+     *
+     */
     public function setPlacerContactPerson($value, int $position = 12): bool
     {
          return $this->setField($position, $value);
     }
 
+    /**
+     * Set Placer ContactPhoneNumber (OBR.13)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 13
+     *
+     * @return bool
+     *
+     */
     public function setPlacerContactPhoneNumber($value, int $position = 13): bool
     {
          return $this->setField($position, $value);
     }
 
+    /**
+     * Set Placer ContactAddress (OBR.14)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 14
+     *
+     * @return bool
+     *
+     */
     public function setPlacerContactAddress($value, int $position = 14): bool
     {
          return $this->setField($position, $value);
     }
 
+    /**
+     * Set Placer ContactLocation (OBR.15)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 15
+     *
+     * @return bool
+     *
+     */
     public function setPlacerContactLocation($value, int $position = 15): bool
     {
          return $this->setField($position, $value);
     }
 
+    /**
+     * Set Filler ContactPerson (OBR.16)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 16
+     *
+     * @return bool
+     *
+     */
     public function setFillerContactPerson($value, int $position = 16): bool
     {
          return $this->setField($position, $value);
     }
 
+    /**
+     * Set Filler ContactPhoneNumber (OBR.17)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 17
+     *
+     * @return bool
+     *
+     */
     public function setFillerContactPhoneNumber($value, int $position = 17): bool
     {
          return $this->setField($position, $value);
     }
 
+    /**
+     * Set Filler ContactAddress (OBR.18)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 18
+     *
+     * @return bool
+     *
+     */
     public function setFillerContactAddress($value, int $position = 18): bool
     {
          return $this->setField($position, $value);
     }
 
+    /**
+     * Set Filler ContactLocation (OBR.19)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 19
+     *
+     * @return bool
+     *
+     */
     public function setFillerContactLocation($value, int $position = 19): bool
     {
          return $this->setField($position, $value);
     }
 
+    /**
+     * Set Enteredby Person (OBR.20)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 20
+     *
+     * @return bool
+     *
+     */
     public function setEnteredbyPerson($value, int $position = 20): bool
     {
          return $this->setField($position, $value);
     }
 
+    /**
+     * Set Enteredby PhoneNumber (OBR.21)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 21
+     *
+     * @return bool
+     *
+     */
     public function setEnteredbyPhoneNumber($value, int $position = 21): bool
     {
          return $this->setField($position, $value);
     }
 
+    /**
+     * Set Enteredby Location (OBR.22)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 22
+     *
+     * @return bool
+     *
+     */
     public function setEnteredbyLocation($value, int $position = 22): bool
     {
          return $this->setField($position, $value);
     }
 
+    /**
+     * Set Parent PlacerAppointmentID (OBR.23)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 23
+     *
+     * @return bool
+     *
+     */
     public function setParentPlacerAppointmentID($value, int $position = 23): bool
     {
          return $this->setField($position, $value);
     }
 
+    /**
+     * Set Parent FillerAppointmentID (OBR.24)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 24
+     *
+     * @return bool
+     *
+     */
     public function setParentFillerAppointmentID($value, int $position = 24): bool
     {
          return $this->setField($position, $value);
     }
 
+    /**
+     * Set Filler StatusCode (OBR.25)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 25
+     *
+     * @return bool
+     *
+     */
     public function setFillerStatusCode($value, int $position = 25): bool
     {
          return $this->setField($position, $value);
     }
 
+    /**
+     * Get Placer AppointmentID (OBR.1)
+     *
+     * @param int $position Defaults to 1
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getPlacerAppointmentID(int $position = 1)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Filler AppointmentID (OBR.2)
+     *
+     * @param int $position Defaults to 2
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getFillerAppointmentID(int $position = 2)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Occurrence Number (OBR.3)
+     *
+     * @param int $position Defaults to 3
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getOccurrenceNumber(int $position = 3)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Placer GroupNumber (OBR.4)
+     *
+     * @param int $position Defaults to 4
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getPlacerGroupNumber(int $position = 4)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Schedule ID (OBR.5)
+     *
+     * @param int $position Defaults to 5
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getScheduleID(int $position = 5)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Event Reason (OBR.6)
+     *
+     * @param int $position Defaults to 6
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getEventReason(int $position = 6)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Appointment Reason (OBR.7)
+     *
+     * @param int $position Defaults to 7
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getAppointmentReason(int $position = 7)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Appointment Type (OBR.8)
+     *
+     * @param int $position Defaults to 8
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getAppointmentType(int $position = 8)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Appointment Duration (OBR.9)
+     *
+     * @param int $position Defaults to 9
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getAppointmentDuration(int $position = 9)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Appointment DurationUnits (OBR.10)
+     *
+     * @param int $position Defaults to 10
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getAppointmentDurationUnits(int $position = 10)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Appointment TimingQuantity (OBR.11)
+     *
+     * @param int $position Defaults to 11
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getAppointmentTimingQuantity(int $position = 11)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Placer ContactPerson (OBR.12)
+     *
+     * @param int $position Defaults to 12
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getPlacerContactPerson(int $position = 12)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Placer ContactPhoneNumber (OBR.13)
+     *
+     * @param int $position Defaults to 13
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getPlacerContactPhoneNumber(int $position = 13)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Placer ContactAddress (OBR.14)
+     *
+     * @param int $position Defaults to 14
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getPlacerContactAddress(int $position = 14)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Placer ContactLocation (OBR.15)
+     *
+     * @param int $position Defaults to 15
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getPlacerContactLocation(int $position = 15)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Filler ContactPerson (OBR.16)
+     *
+     * @param int $position Defaults to 16
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getFillerContactPerson(int $position = 16)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Filler ContactPhoneNumber (OBR.17)
+     *
+     * @param int $position Defaults to 17
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getFillerContactPhoneNumber(int $position = 17)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Filler ContactAddress (OBR.18)
+     *
+     * @param int $position Defaults to 18
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getFillerContactAddress(int $position = 18)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Filler ContactLocation (OBR.19)
+     *
+     * @param int $position Defaults to 19
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getFillerContactLocation(int $position = 19)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Enteredby Person (OBR.20)
+     *
+     * @param int $position Defaults to 20
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getEnteredbyPerson(int $position = 20)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Enteredby PhoneNumber (OBR.21)
+     *
+     * @param int $position Defaults to 21
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getEnteredbyPhoneNumber(int $position = 21)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Enteredby Location (OBR.22)
+     *
+     * @param int $position Defaults to 22
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getEnteredbyLocation(int $position = 22)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Parent PlacerAppointmentID (OBR.23)
+     *
+     * @param int $position Defaults to 23
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getParentPlacerAppointmentID(int $position = 23)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Parent FillerAppointmentID (OBR.24)
+     *
+     * @param int $position Defaults to 24
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getParentFillerAppointmentID(int $position = 24)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Filler StatusCode (OBR.25)
+     *
+     * @param int $position Defaults to 25
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getFillerStatusCode(int $position = 25)
     {
         return $this->getField($position);

--- a/src/HL7/Segments/TQ1.php
+++ b/src/HL7/Segments/TQ1.php
@@ -22,66 +22,183 @@ class TQ1 extends Segment
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Quantity (OBR.2)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 2
+     *
+     * @return bool
+     *
+     */
     public function setQuantity($value, int $position = 2): bool
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Repeat Pattern (OBR.3)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 3
+     *
+     * @return bool
+     *
+     */
     public function setRepeatPattern($value, int $position = 3): bool
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Explicit Time (OBR.4)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 4
+     *
+     * @return bool
+     *
+     */
     public function setExplicitTime($value, int $position = 4): bool
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Relative TimeAndUnits (OBR.5)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 5
+     *
+     * @return bool
+     *
+     */
     public function setRelativeTimeAndUnits($value, int $position = 5): bool
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Service Duration (OBR.6)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 6
+     *
+     * @return bool
+     *
+     */
     public function setServiceDuration($value, int $position = 6): bool
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Start DateTime (OBR.7)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 7
+     *
+     * @return bool
+     *
+     */
     public function setStartDateTime($value, int $position = 7): bool
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set End DateTime (OBR.8)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 8
+     *
+     * @return bool
+     *
+     */
     public function setEndDateTime($value, int $position = 8): bool
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Priority (OBR.9)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 9
+     *
+     * @return bool
+     *
+     */
     public function setPriority($value, int $position = 9): bool
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Condition Text (OBR.10)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 10
+     *
+     * @return bool
+     *
+     */
     public function setConditionText($value, int $position = 10): bool
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Text Instruction (OBR.11)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 11
+     *
+     * @return bool
+     *
+     */
     public function setTextInstruction($value, int $position = 11): bool
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Conjunction (OBR.12)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 12
+     *
+     * @return bool
+     *
+     */
     public function setConjunction($value, int $position = 12): bool
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Occurrence Duration (OBR.13)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 13
+     *
+     * @return bool
+     *
+     */
     public function setOccurrenceDuration($value, int $position = 13): bool
     {
         return $this->setField($position, $value);
     }
 
+    /**
+     * Set Total Occurrences (OBR.14)
+     *
+     * @param string|int|array|null $value
+     * @param int $position Defaults to 14
+     *
+     * @return bool
+     *
+     */
     public function setTotalOccurrences($value, int $position = 14): bool
     {
         return $this->setField($position, $value);
@@ -92,66 +209,170 @@ class TQ1 extends Segment
         return $this->getField($position);
     }
 
+    /**
+     * Get Quantity (OBR.2)
+     *
+     * @param int $position Defaults to 2
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getQuantity(int $position = 2)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Repeat Pattern (OBR.3)
+     *
+     * @param int $position Defaults to 3
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getRepeatPattern(int $position = 3)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Explicit Time (OBR.4)
+     *
+     * @param int $position Defaults to 4
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getExplicitTime(int $position = 4)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Relative TimeAndUnits (OBR.5)
+     *
+     * @param int $position Defaults to 5
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getRelativeTimeAndUnits(int $position = 5)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Service Duration (OBR.6)
+     *
+     * @param int $position Defaults to 6
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getServiceDuration(int $position = 6)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Start DateTime (OBR.7)
+     *
+     * @param int $position Defaults to 7
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getStartDateTime(int $position = 7)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get End DateTime (OBR.8)
+     *
+     * @param int $position Defaults to 8
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getEndDateTime(int $position = 8)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Priority (OBR.9)
+     *
+     * @param int $position Defaults to 9
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getPriority(int $position = 9)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Condition Text (OBR.10)
+     *
+     * @param int $position Defaults to 10
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getConditionText(int $position = 10)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Text Instruction (OBR.11)
+     *
+     * @param int $position Defaults to 11
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getTextInstruction(int $position = 11)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Conjunction (OBR.12)
+     *
+     * @param int $position Defaults to 12
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getConjunction(int $position = 12)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Occurrence Duration (OBR.13)
+     *
+     * @param int $position Defaults to 13
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getOccurrenceDuration(int $position = 13)
     {
         return $this->getField($position);
     }
 
+    /**
+     * Get Total Occurrences (OBR.14)
+     *
+     * @param int $position Defaults to 14
+     *
+     * @return array|string|int|null
+     *
+     */
     public function getTotalOccurrences(int $position = 14)
     {
         return $this->getField($position);


### PR DESCRIPTION
This adds docblock to all of the segment getter/setter methods, primarily so that pages like [this](https://github.com/jay-knight/HL7/blob/feature/improve-generated-docs/docs/Segments/MSH.md) include the field numbers that they use.

I used this sed script to generate them:

```sed
# Add docblock to setters
s/public function set\([A-Za-z]*\)($value, int $position = \([0-9]*\)/\/**\
     * Set \1 (OBR.\2)\
     *\
     * @param string|int|array|null $value\
     * @param int $position Defaults to \2\
     *\
     * @return bool\
     *\
     *\/\
    \0/

# Add docblock to getters
s/public function get\([A-Za-z]*\)(int $position = \([0-9]*\)/\/**\
     * Get \1 (OBR.\2)\
     *\
     * @param int $position Defaults to \2\
     *\
     * @return array|string|int|null\
     *\
     *\/\
    \0/

# Add spaces to camel case descriptions
/\* [GS]et [A-Z][^\n]*[a-z][A-Z]/s/\([a-z]\)\([A-Z]\)/\1 \2/
```