### PR TITLE
Allow array on setPatientIdentifierList field (PID.3)

### DIFF
--- a/src/HL7/Segments/PID.php
+++ b/src/HL7/Segments/PID.php
@@ -51,7 +51,7 @@ class PID extends Segment
 
     /**
      * Patient ID (Internal ID)
-     * @param string $value
+     * @param string|array $value
      */
     public function setPatientIdentifierList($value, int $position = 3): bool
     {


### PR DESCRIPTION
The field can accept a string or an array, the current phpdoc causes conflicts in some IDEs.

https://hl7-definition.caristix.com/v2/HL7v2.3/Fields/PID.3

https://hl7-definition.caristix.com/v2/HL7v2.5/Fields/PID.3