### PR TITLE
PHP 8.4: Fix 'Implicitly marking parameter as nullable is deprecated'

### DIFF
--- a/src/HL7/Message.php
+++ b/src/HL7/Message.php
@@ -58,12 +58,12 @@ class Message
      * @throws HL7Exception
      */
     public function __construct(
-        string $msgStr = null,
-        array $hl7Globals = null,
+        ?string $msgStr = null,
+        ?array $hl7Globals = null,
         bool $keepEmptySubFields = false,
         bool $resetIndices = false,
         bool $autoIncrementIndices = true,
-        bool $doNotSplitRepetition = null
+        ?bool $doNotSplitRepetition = null
     ) {
         // Control characters and other HL7 properties
         $this->segmentSeparator = $hl7Globals['SEGMENT_SEPARATOR'] ?? '\n';
@@ -129,7 +129,7 @@ class Message
      * @param null|int $index Index where segment is inserted
      * @throws InvalidArgumentException
      */
-    public function insertSegment(Segment $segment, int $index = null): void
+    public function insertSegment(Segment $segment, ?int $index = null): void
     {
         if ($index > count($this->segments)) {
             throw new InvalidArgumentException("Index out of range. Index: $index, Total segments: " .

--- a/src/HL7/Messages/ACK.php
+++ b/src/HL7/Messages/ACK.php
@@ -29,7 +29,7 @@ class ACK extends Message
      * @throws Exception
      * @throws InvalidArgumentException
      */
-    public function __construct(Message $req = null, MSH $reqMsh = null, array $hl7Globals = null)
+    public function __construct(?Message $req = null, ?MSH $reqMsh = null, ?array $hl7Globals = null)
     {
         parent::__construct(null, $hl7Globals);
 
@@ -82,7 +82,7 @@ class ACK extends Message
      * @param  string  $code  Code to use in acknowledgement
      * @param  string|null  $msg  Acknowledgement message
      */
-    public function setAckCode(string $code, string $msg = null): bool
+    public function setAckCode(string $code, ?string $msg = null): bool
     {
         $mode = 'A';
 

--- a/src/HL7/Segment.php
+++ b/src/HL7/Segment.php
@@ -32,7 +32,7 @@ class Segment
      * @param array|null $fields Fields for segment
      * @throws InvalidArgumentException
      */
-    public function __construct(string $name, array $fields = null)
+    public function __construct(string $name, ?array $fields = null)
     {
         // Is the name 3 upper case characters?
         if ((!$name) || (strlen($name) !== 3) || (strtoupper($name) !== $name)) {
@@ -144,7 +144,7 @@ class Segment
      * @param int|null $to Stop range at this index
      * @return array List of fields
      */
-    public function getFields(int $from = 0, int $to = null): array
+    public function getFields(int $from = 0, ?int $to = null): array
     {
         if (!$to) {
             $to = count($this->fields);

--- a/src/HL7/Segments/AIG.php
+++ b/src/HL7/Segments/AIG.php
@@ -26,7 +26,7 @@ class AIG extends Segment
      */
     protected static $setId = 1;
 
-    public function __construct(array $fields = null)
+    public function __construct(?array $fields = null)
     {
         parent::__construct('AIG', $fields);
         $this->setID($this::$setId++);

--- a/src/HL7/Segments/AIL.php
+++ b/src/HL7/Segments/AIL.php
@@ -27,7 +27,7 @@ class AIL extends Segment
      */
     protected static $setId = 1;
 
-    public function __construct(array $fields = null)
+    public function __construct(?array $fields = null)
     {
         parent::__construct('AIL', $fields);
         $this->setID($this::$setId++);

--- a/src/HL7/Segments/AIP.php
+++ b/src/HL7/Segments/AIP.php
@@ -27,7 +27,7 @@ class AIP extends Segment
      */
     protected static $setId = 1;
 
-    public function __construct(array $fields = null)
+    public function __construct(?array $fields = null)
     {
         parent::__construct('AIP', $fields);
         $this->setID($this::$setId++);

--- a/src/HL7/Segments/DG1.php
+++ b/src/HL7/Segments/DG1.php
@@ -17,7 +17,7 @@ class DG1 extends Segment
      */
     protected static int $setId = 1;
 
-    public function __construct(array $fields = null, bool $autoIncrementIndices = true)
+    public function __construct(?array $fields = null, bool $autoIncrementIndices = true)
     {
         parent::__construct('DG1', $fields);
         if ($autoIncrementIndices) {

--- a/src/HL7/Segments/EQU.php
+++ b/src/HL7/Segments/EQU.php
@@ -18,7 +18,7 @@ class EQU extends Segment
      */
     protected static $setId = 1;
 
-    public function __construct(array $fields = null)
+    public function __construct(?array $fields = null)
     {
         parent::__construct('EQU', $fields);
     }

--- a/src/HL7/Segments/EVN.php
+++ b/src/HL7/Segments/EVN.php
@@ -11,7 +11,7 @@ use Aranyasen\HL7\Segment;
  */
 class EVN extends Segment
 {
-    public function __construct(array $fields = null)
+    public function __construct(?array $fields = null)
     {
         parent::__construct('EVN', $fields);
     }

--- a/src/HL7/Segments/FHS.php
+++ b/src/HL7/Segments/FHS.php
@@ -12,7 +12,7 @@ use Aranyasen\HL7\Segment;
  */
 class FHS extends Segment
 {
-    public function __construct(array $fields = null)
+    public function __construct(?array $fields = null)
     {
         parent::__construct('FHS', $fields);
     }

--- a/src/HL7/Segments/FTS.php
+++ b/src/HL7/Segments/FTS.php
@@ -12,7 +12,7 @@ use Aranyasen\HL7\Segment;
  */
 class FTS extends Segment
 {
-    public function __construct(array $fields = null)
+    public function __construct(?array $fields = null)
     {
         parent::__construct('FTS', $fields);
     }

--- a/src/HL7/Segments/GT1.php
+++ b/src/HL7/Segments/GT1.php
@@ -19,7 +19,7 @@ class GT1 extends Segment
      */
     protected static $setId = 1;
 
-    public function __construct(array $fields = null, bool $autoIncrementIndices = true)
+    public function __construct(?array $fields = null, bool $autoIncrementIndices = true)
     {
         parent::__construct('GT1', $fields);
         if ($autoIncrementIndices) {

--- a/src/HL7/Segments/IN1.php
+++ b/src/HL7/Segments/IN1.php
@@ -18,7 +18,7 @@ class IN1 extends Segment
      */
     protected static $setId = 1;
 
-    public function __construct(array $fields = null, bool $autoIncrementIndices = true)
+    public function __construct(?array $fields = null, bool $autoIncrementIndices = true)
     {
         parent::__construct('IN1', $fields);
         if ($autoIncrementIndices) {

--- a/src/HL7/Segments/IN3.php
+++ b/src/HL7/Segments/IN3.php
@@ -18,7 +18,7 @@ class IN3 extends Segment
      */
     protected static $setId = 1;
 
-    public function __construct(array $fields = null, bool $autoIncrementIndices = true)
+    public function __construct(?array $fields = null, bool $autoIncrementIndices = true)
     {
         parent::__construct('IN3', $fields);
         if ($autoIncrementIndices) {

--- a/src/HL7/Segments/MRG.php
+++ b/src/HL7/Segments/MRG.php
@@ -12,7 +12,7 @@ use Aranyasen\HL7\Segment;
  */
 class MRG extends Segment
 {
-    public function __construct(array $fields = null)
+    public function __construct(?array $fields = null)
     {
         parent::__construct('MRG', $fields);
     }

--- a/src/HL7/Segments/MSA.php
+++ b/src/HL7/Segments/MSA.php
@@ -12,7 +12,7 @@ use Aranyasen\HL7\Segment;
  */
 class MSA extends Segment
 {
-    public function __construct(array $fields = null)
+    public function __construct(?array $fields = null)
     {
         parent::__construct('MSA', $fields);
     }

--- a/src/HL7/Segments/MSH.php
+++ b/src/HL7/Segments/MSH.php
@@ -40,7 +40,7 @@ class MSH extends Segment
      * @param null|array $hl7Globals
      * @throws InvalidArgumentException|Exception
      */
-    public function __construct(array $fields = null, array $hl7Globals = null)
+    public function __construct(?array $fields = null, ?array $hl7Globals = null)
     {
         parent::__construct('MSH', $fields);
 

--- a/src/HL7/Segments/NK1.php
+++ b/src/HL7/Segments/NK1.php
@@ -21,7 +21,7 @@ class NK1 extends Segment
      */
     protected static $setId = 1;
 
-    public function __construct(array $fields = null, bool $autoIncrementIndices = true)
+    public function __construct(?array $fields = null, bool $autoIncrementIndices = true)
     {
         parent::__construct('NK1', $fields);
         if ($autoIncrementIndices) {

--- a/src/HL7/Segments/NTE.php
+++ b/src/HL7/Segments/NTE.php
@@ -18,7 +18,7 @@ class NTE extends Segment
      */
     protected static $setId = 1;
 
-    public function __construct(array $fields = null, bool $autoIncrementIndices = true)
+    public function __construct(?array $fields = null, bool $autoIncrementIndices = true)
     {
         parent::__construct('NTE', $fields);
         if ($autoIncrementIndices) {

--- a/src/HL7/Segments/OBR.php
+++ b/src/HL7/Segments/OBR.php
@@ -18,7 +18,7 @@ class OBR extends Segment
      */
     protected static $setId = 1;
 
-    public function __construct(array $fields = null, bool $autoIncrementIndices = true)
+    public function __construct(?array $fields = null, bool $autoIncrementIndices = true)
     {
         parent::__construct('OBR', $fields);
         if ($autoIncrementIndices) {

--- a/src/HL7/Segments/OBX.php
+++ b/src/HL7/Segments/OBX.php
@@ -17,7 +17,7 @@ class OBX extends Segment
      */
     protected static int $setId = 1;
 
-    public function __construct(array $fields = null, bool $autoIncrementIndices = true)
+    public function __construct(?array $fields = null, bool $autoIncrementIndices = true)
     {
         parent::__construct('OBX', $fields);
         if ($autoIncrementIndices) {

--- a/src/HL7/Segments/ORC.php
+++ b/src/HL7/Segments/ORC.php
@@ -12,7 +12,7 @@ use Aranyasen\HL7\Segment;
  */
 class ORC extends Segment
 {
-    public function __construct(array $fields = null)
+    public function __construct(?array $fields = null)
     {
         parent::__construct('ORC', $fields);
     }

--- a/src/HL7/Segments/PID.php
+++ b/src/HL7/Segments/PID.php
@@ -18,7 +18,7 @@ class PID extends Segment
      */
     protected static int $setId = 1;
 
-    public function __construct(array $fields = null, bool $autoIncrementIndices = true)
+    public function __construct(?array $fields = null, bool $autoIncrementIndices = true)
     {
         parent::__construct('PID', $fields);
         if ($autoIncrementIndices) {

--- a/src/HL7/Segments/PV1.php
+++ b/src/HL7/Segments/PV1.php
@@ -18,7 +18,7 @@ class PV1 extends Segment
      */
     protected static $setId = 1;
 
-    public function __construct(array $fields = null, bool $autoIncrementIndices = true)
+    public function __construct(?array $fields = null, bool $autoIncrementIndices = true)
     {
         parent::__construct('PV1', $fields);
         if ($autoIncrementIndices) {

--- a/src/HL7/Segments/PV2.php
+++ b/src/HL7/Segments/PV2.php
@@ -13,9 +13,9 @@ use Aranyasen\HL7\Segment;
 class PV2 extends Segment
 {
     /**
-     * @param array|null $fields
+     * @param ?array $fields
      */
-    public function __construct(array $fields = null)
+    public function __construct(?array $fields = null)
     {
         parent::__construct('PV2', $fields);
     }

--- a/src/HL7/Segments/RGS.php
+++ b/src/HL7/Segments/RGS.php
@@ -17,7 +17,7 @@ class RGS extends Segment
      */
     protected static int $setId = 1;
 
-    public function __construct(array $fields = null, bool $autoIncrementIndices = true)
+    public function __construct(?array $fields = null, bool $autoIncrementIndices = true)
     {
         parent::__construct('RGS', $fields);
         if ($autoIncrementIndices) {

--- a/src/HL7/Segments/SAC.php
+++ b/src/HL7/Segments/SAC.php
@@ -18,7 +18,7 @@ class SAC extends Segment
      */
     protected static $setId = 1;
 
-    public function __construct(array $fields = null)
+    public function __construct(?array $fields = null)
     {
         parent::__construct('SAC', $fields);
     }

--- a/src/HL7/Segments/SCH.php
+++ b/src/HL7/Segments/SCH.php
@@ -13,7 +13,7 @@ use Aranyasen\HL7\Segment;
  */
 class SCH extends Segment
 {
-    public function __construct(array $fields = null)
+    public function __construct(?array $fields = null)
     {
         parent::__construct('SCH', $fields);
     }

--- a/src/HL7/Segments/TQ1.php
+++ b/src/HL7/Segments/TQ1.php
@@ -12,7 +12,7 @@ use Aranyasen\HL7\Segment;
  */
 class TQ1 extends Segment
 {
-    public function __construct(array $fields = null)
+    public function __construct(?array $fields = null)
     {
         parent::__construct('TQ1', $fields);
     }


### PR DESCRIPTION
In PHP 8.4, implicitly nullable function parameters are [deprecated](https://www.php.net/manual/en/migration84.deprecated.php). This change makes those explicitly nullable by prepending a `?` so that the tests pass with no deprecation warnings.