### PR TITLE
Function to reindex all segments in a message

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,13 +61,13 @@ $message->isempty(); // Returns true
 // The class `HL7` can be used to build HL7 object. It is a factory class with various helper methods to help build a hl7.
 $message = HL7::build()->createMessage(); // Creates an empty message
 
-// The HL7 factory class provides methods that can be chained together in a fluent fashion 
+// The HL7 factory class provides methods that can be chained together in a fluent fashion
 $message = HL7::build()
     ->withComponentSeparator('#')
     ->withFieldSeparator('-')
     ->createMessage();
 
-// Or, using Message class... 
+// Or, using Message class...
 $message = new Message();
 ```
 #### Message constructor parameters
@@ -85,7 +85,7 @@ $message = new Message("MSH|^~\&|||||||ORM^O01||P|2.3.1|", null, true, true);
 // Use 5th argument as false...
 $hl7String = "MSH|^~\&|||||||ORU^R01|00001|P|2.3.1|\n" . "OBX|1||11^AA|\n" . "OBX|1||22^BB|\n";
 $message = new Message($hl7String, null, true, true, false); $// $message contains both OBXs with given indexes in the string
-```    
+```
 ```php
 // Create a segment with empty sub-fields retained
 $message = new Message("MSH|^~\\&|1|\rPV1|1|O|^AAAA1^^^BB|", null, true); // Third argument 'true' forces to keep all sub-fields
@@ -95,14 +95,14 @@ $fields = $pv1->getField(3); // $fields is ['', 'AAAA1', '', '', 'BB']
 // Create/send message with segment-ending bar character (|) removed
 $message = new Message("MSH|^~\\&|1|\nABC|||xxx\n", ['SEGMENT_ENDING_BAR' => false]);
 $message->toString(true); // Returns "MSH|^~\&|1\nABC|||xxx\n"
-(new Connection($ip, $port))->send($message); // Sends the message without ending bar-characters (details on Connection below) 
+(new Connection($ip, $port))->send($message); // Sends the message without ending bar-characters (details on Connection below)
 
 // Specify custom values for separators, HL7 version etc.
 $message = new Message("MSH|^~\\&|1|\rPV1|1|O|^AAAA1^^^BB|", ['SEGMENT_SEPARATOR' => '\r\n', 'HL7_VERSION' => '2.3']);
 
 // Segment with separator character (~) creates sub-arrays containing each sub-segment
 $message = new Message("MSH|^~\&|||||||ADT^A01||P|2.3.1|\nPID|||3^0~4^1"); // Creates [[3,0], [4,1]]
-        
+
 // To create a single array instead, pass 'true' as 6th argument. This may be used to retain behavior from previous releases
 // Notice: Since this leads to a non-standard behavior, it may be removed in future
 $message = new Message("MSH|^~\&|||||||ADT^A01||P|2.3.1|\nPID|||3^0~4^1", null, false, false, true, true); // Creates ['3', '0~4', '1']
@@ -127,11 +127,15 @@ $abc->clearField(2); // Clear the value from field 2
 $message->setSegment($abc, 1); // Message is now: "MSH|^~\&|||||20171116140058|||2017111614005840157||2.3|\nABC|xyz|\n"
 
 // Create a defined segment (To know which segments are defined in this package, look into Segments/ directory)
-// Advantages of defined segments over custom ones (shown above) are 1) Helpful setter methods, 2) Auto-incrementing segment index 
+// Advantages of defined segments over custom ones (shown above) are 1) Helpful setter methods, 2) Auto-incrementing segment index
 $pid = new PID(); // Automatically creates PID segment, and adds segment index at PID.1
 $pid->setPatientName([$lastname, $firstname, $middlename, $suffix]); // Use a setter method to add patient's name at standard position (PID.5)
 $pid->setField('abcd', 5); // Apart from standard setter methods, you can manually set a value at any position too
 unset($pid); // Destroy the segment and decrement the id number. Useful when you want to discard a segment.
+
+// It is possible that segments get added in a way that the Set IDs/Sequence IDs within the message are not in order or leave gaps. To reset all Set/Sequence IDs in the message:
+
+$message->reindexSegments();
 ```
 
 ### Send messages to remote listeners
@@ -149,7 +153,7 @@ $response = $connection->send($message); // Send to the listener, and get a resp
 echo $response->toString(true); // Prints ACK from the listener
 ```
 ### ACK
-Handle ACK message returned from a remote HL7 listener... 
+Handle ACK message returned from a remote HL7 listener...
 ```php
 $ack = (new Connection($ip, $port))->send($message); // Send a HL7 to remote listener
 $returnString = $ack->toString(true);
@@ -184,19 +188,19 @@ This package exposes a number of public methods for convenient HL7 handling. Som
     $msg->toFile('/path/to/some.hl7'); // Write to a file
     $msg->isOru(); // Check if it's an ORU
     $msg->isOrm(); // Check if it's an ORM
-``` 
+```
 
 Visit [docs\README](docs/README.md) for details on available APIs
 
-All segment level getter/setter APIs can be used in two ways - 
-* If a position index isn't provided as argument (1st argument for getters, 2nd for setters), a standard index is used.  
-`$pid->setPatientName('John Doe')` -> Set patient name at position 5 as per HL7 v2.3 [standard](https://corepointhealth.com/resource-center/hl7-resources/hl7-pid-segment)  
+All segment level getter/setter APIs can be used in two ways -
+* If a position index isn't provided as argument (1st argument for getters, 2nd for setters), a standard index is used.
+`$pid->setPatientName('John Doe')` -> Set patient name at position 5 as per HL7 v2.3 [standard](https://corepointhealth.com/resource-center/hl7-resources/hl7-pid-segment)
 `$pid->getPatientAddress()` -> Get patient address from standard 11th position
 
 
-* To use a custom position index, provide it in the argument:  
-`$pid->setPatientName('John Doe', 6)` -> Set patient name at 6th position in PID segment  
-`$pid->getPatientAddress(12)` -> Get patient address from 12th position  
+* To use a custom position index, provide it in the argument:
+`$pid->setPatientName('John Doe', 6)` -> Set patient name at 6th position in PID segment
+`$pid->getPatientAddress(12)` -> Get patient address from 12th position
 
 ### Issues
 Bug reports and feature requests can be submitted on the [Github Issue Tracker](https://github.com/senaranya/HL7/issues).

--- a/src/HL7/Message.php
+++ b/src/HL7/Message.php
@@ -333,7 +333,7 @@ class Message
     {
         $indexes = [];
         foreach ($this->segments as $segment) {
-            if (is_a($segment, MSH::class)) {
+            if (!method_exists($segment, "setID")) {
                 continue;
             }
 

--- a/src/HL7/Message.php
+++ b/src/HL7/Message.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Aranyasen\HL7;
 
 use Aranyasen\Exceptions\HL7Exception;
+use Aranyasen\HL7\Segments\MSH;
 use InvalidArgumentException;
 
 /**
@@ -323,6 +324,25 @@ class Message
     public function getSegments(): array
     {
         return $this->segments;
+    }
+
+    /**
+     * Reindex all of the segments in the message
+     */
+    public function reindexSegments(): void
+    {
+        $indexes = [];
+        foreach ($this->segments as $segment) {
+            if (is_a($segment, MSH::class)) {
+                continue;
+            }
+
+            if (!array_key_exists(get_class($segment), $indexes)) {
+                $indexes[get_class($segment)] = 1;
+            }
+
+            $segment->setId($indexes[get_class($segment)]++);
+        }
     }
 
     /**

--- a/src/HL7/Message.php
+++ b/src/HL7/Message.php
@@ -333,15 +333,12 @@ class Message
     {
         $indexes = [];
         foreach ($this->segments as $segment) {
-            if (!method_exists($segment, "setID")) {
-                continue;
+            if (method_exists($segment, "setID")) {
+                if (!array_key_exists($segment->getName(), $indexes)) {
+                    $indexes[$segment->getName()] = 1;
+                }
+                $segment->setId($indexes[$segment->getName()]++);
             }
-
-            if (!array_key_exists(get_class($segment), $indexes)) {
-                $indexes[get_class($segment)] = 1;
-            }
-
-            $segment->setId($indexes[get_class($segment)]++);
         }
     }
 

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -635,4 +635,32 @@ class MessageTest extends TestCase
         $OBRs = $message->getSegmentsByClass(OBR::class);
         self::assertCount(0, $OBRs);
     }
+
+    /** @test */
+    public function reindex_message_segments(): void
+    {
+        $message = new Message(autoIncrementIndices: false);
+        $pid = new PID();
+        $pid->setId(2);
+        $message->addSegment($pid);
+
+        $obx1 = new OBX();
+        $obx1->setId(3);
+        $obx1->setValueType("ST");
+        $message->addSegment($obx1);
+
+        $obx2 = new OBX();
+        $obx2->setId(1);
+        $obx2->setValueType("CWE");
+        $message->addSegment($obx2);
+
+        $message->reindexSegments();
+        $PIDs = $message->getSegmentsByClass(PID::class);
+        self::assertSame(1, $PIDs[0]->getId());
+        $OBXs = $message->getSegmentsByClass(OBX::class);
+        self::assertSame(1, $OBXs[0]->getId());
+        self::assertSame("ST", $OBXs[0]->getValueType());
+        self::assertSame(2, $OBXs[1]->getId());
+        self::assertSame("CWE", $OBXs[1]->getValueType());
+    }
 }


### PR DESCRIPTION
This adds a new function to the Message class to re-index all of the segments in a message. When we're reading and building multiple messages, the index/sequence ids can be added in weird and unpredictable ways because of the static/global `$setId` variables.

This solution lets you add any segments you need and then step through and re-index all of the segments so that each segment types starts with 1 and increases by 1 for each segment of that type.

I think a better solution might be to keep up with the segment ids in the Message class (as an instance variable, instead of static variables on each segment class) so that as you add segments they can be set/incremented if that option is set. And multiple messages wouldn't interfere with each other.