### PR TITLE
Docs: Update PHP_CodeSniffer repository link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 * Contributions are more than welcome!
 * Please review [issues](https://github.com/senaranya/HL7/issues) if you want to pick up from existing tickets. New tickets/features/CRs/PRs are welcome!
 * The goal of this library is to keep it generic and minimal. The focus should only be on basic HL7-related operations like creation/parsing/sending/receiving etc. No project-specific business logic should be included.
-* This library follows PSR-12 standards for coding style. You may use [phpcs](https://github.com/squizlabs/PHP_CodeSniffer#getting-started) to verify your code.
+* This library follows PSR-12 standards for coding style. You may use [phpcs](https://github.com/PHPCSStandards/PHP_CodeSniffer#getting-started) to verify your code.
 * Add unit tests for code changes/updates. There are a number of existing tests, follow those as reference
 * For a PR on bug, please include test(s) that reproduces the bug
 * Contributors are requested to add or update phpdoc for any new or existing methods being worked on. After updating/adding, please update the API documentation as well (details below)


### PR DESCRIPTION
PHP_CodeSniffer has moved to a new GitHub organization. The `squizlabs/PHP_CodeSniffer` repository is now archived and the project is actively maintained at https://github.com/PHPCSStandards/PHP_CodeSniffer.

See: https://github.com/squizlabs/PHP_CodeSniffer/issues/3932