### PR TITLE
Handle components/subcomponents within hl7version field (MSH-12)

### DIFF
--- a/src/HL7/Message.php
+++ b/src/HL7/Message.php
@@ -128,7 +128,8 @@ class Message
         }
 
         if ($segment->getField(12)) {
-            $this->hl7Version = $segment->getField(12);
+            $field = $segment->getField(12);
+            $this->hl7Version = is_array($field) ? implode($this->componentSeparator, $field) : (string) $field;
         }
 
         return true;

--- a/src/HL7/Message.php
+++ b/src/HL7/Message.php
@@ -129,7 +129,14 @@ class Message
 
         if ($segment->getField(12)) {
             $field = $segment->getField(12);
-            $this->hl7Version = is_array($field) ? implode($this->componentSeparator, $field) : (string) $field;
+            if (is_array($field)) {
+                $this->hl7Version = implode($this->componentSeparator, array_map(
+                    fn($v) => is_array($v) ? implode($this->subcomponentSeparator, $v) : (string) $v,
+                    $field
+                ));
+            } else {
+                $this->hl7Version = (string) $field;
+            }
         }
 
         return true;

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -668,8 +668,6 @@ class MessageTest extends TestCase
     #[Test] public function version_field_with_subcomponents_in_MSH_12_is_parsed_to_correct_string(): void
     {
         $msg = new Message("MSH|^~\\&||||||||||2.7^NZL&1.0\r");
-
-        $reflection = new \ReflectionProperty(Message::class, 'hl7Version');
-        self::assertSame('2.7^NZL&1.0', $reflection->getValue($msg));
+        self::assertSame("MSH|^~\&||||||||||2.7^NZL&1.0|\n", $msg->toString(true));
     }
 }

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -664,4 +664,12 @@ class MessageTest extends TestCase
 
         self::assertSame([0, 1, 2], array_keys($msgObj->getSegments()));
     }
+
+    #[Test] public function version_field_with_subcomponents_in_MSH_12_is_parsed_to_correct_string(): void
+    {
+        $msg = new Message("MSH|^~\\&||||||||||2.7^NZL&1.0\r");
+
+        $reflection = new \ReflectionProperty(Message::class, 'hl7Version');
+        self::assertSame('2.7^NZL&1.0', $reflection->getValue($msg));
+    }
 }


### PR DESCRIPTION
When the MSH-12 field (HL7 version) has components, getField(12) returns an array which causes a type error with $this->hl7Version (which is a string)