### PR TITLE
Add templated types to getSegmentsByClass and getFirstSegmentInstanceByClass

### DIFF
--- a/src/HL7/SegmentManagerTrait.php
+++ b/src/HL7/SegmentManagerTrait.php
@@ -359,8 +359,9 @@ trait SegmentManagerTrait
     /**
      * Return an array of all segments with the given subclass of Segment
      *
-     * @param  string  $segmentClass  Segment class
-     * @return array List of segments identified by class
+     * @template T of Segment
+     * @param  class-string<T>  $segmentClass  Segment class
+     * @return array<T> List of segments identified by class
      * @throws HL7Exception
      */
     public function getSegmentsByClass(string $segmentClass): array
@@ -426,10 +427,12 @@ trait SegmentManagerTrait
     /**
      * Return the first segment of the given class in the message
      *
-     * @return mixed|null
+     * @template T of Segment
+     * @param class-string<T> $segmentClass
+     * @return ?T
      * @throws HL7Exception
      */
-    public function getFirstSegmentInstanceByClass(string $segmentClass): Segment|null
+    public function getFirstSegmentInstanceByClass(string $segmentClass): ?Segment
     {
         if (!$this->hasSegmentOfClass($segmentClass)) {
             return null;


### PR DESCRIPTION
Consider code like

```php
$ORC = $message->getFirstSegmentInstanceByClass(ORC::class);
$ORC->getOrderControl();
```

PHPStan will complain that `Call to an undefined method Aranyasen\HL7\Segment::getOrderControl()`. This is because that function declares that it will return a `Segment` object, but it doesn't specify which subclass of Segment, so it doesn't know to look in the ORC class for the method.  Using the `@template` phpdoc annotation, you can specify that the [return type will be the same as the class string you pass in](https://phpstan.org/blog/generics-in-php-using-phpdocs#class-names).

This PR adds this, which resolves a lot of PHPstan errors in our codebase.